### PR TITLE
feat: media management

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -4,6 +4,8 @@ declare global {
   type FullscreenEvents = import('./types').FullscreenEvents;
   type HlsEvents = import('./types').HlsEvents;
   type MediaEvents = import('./types').MediaEvents;
+  type MediaVisibilityEvents = import('./types').MediaVisibilityEvents;
+  type MediaSyncEvents = import('./types').MediaSyncEvents;
   type MediaRequestEvents = import('./types').MediaRequestEvents;
   type ScreenOrientationEvents = import('./types').ScreenOrientationEvents;
   type ScrubberPreviewEvents = import('./types').ScrubberPreviewEvents;
@@ -16,6 +18,8 @@ declare global {
       HlsEvents,
       MediaEvents,
       MediaRequestEvents,
+      MediaVisibilityEvents,
+      MediaSyncEvents,
       ScreenOrientationEvents,
       ScrubberPreviewEvents,
       SliderEvents,

--- a/src/base/observers/IntersectionController.ts
+++ b/src/base/observers/IntersectionController.ts
@@ -16,7 +16,34 @@ export type IntersectionValueCallback = (
 /**
  * The config options for a `IntersectionController`.
  */
-export type IntersectionControllerConfig = IntersectionObserverInit & {
+export type IntersectionControllerConfig = {
+  /**
+   * The element that is used as the viewport for checking visibility of the target. Must be the
+   * ancestor of the target. Defaults to the browser viewport if not specified or if `null`.
+   */
+  root?: Element | Document | null;
+
+  /**
+   * Margin around the root. Can have values similar to the CSS margin property, e.g.
+   * "10px 20px 30px 40px" (top, right, bottom, left). The values can be percentages. This set
+   * of values serves to grow or shrink each side of the root element's bounding box before
+   * computing intersections. Defaults to all zeros.
+   */
+  rootMargin?: string;
+
+  /**
+   * Either a single number or an array of numbers which indicate at what percentage of the
+   * target's visibility the observer's callback should be executed. If you only want to detect
+   * when visibility passes the `50%` mark, you can use a value of `0.5`. If you want the callback
+   * to run every time visibility passes another `25%`, you would specify the array
+   * `[0, 0.25, 0.5, 0.75, 1]`.
+   *
+   * The default is `0` (meaning as soon as even one pixel is visible, the callback will be run).
+   * A value of `1.0` means that the threshold isn't considered passed until every pixel is
+   * visible.
+   */
+  threshold?: number | number[];
+
   /**
    * The element to observe. In addition to configuring the target here, the `observe` method
    * can be called to observe additional targets. When not specified, the target defaults to

--- a/src/base/observers/IntersectionController.ts
+++ b/src/base/observers/IntersectionController.ts
@@ -7,14 +7,14 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 import { LogDispatcher } from '../logger';
 
 /**
- * The callback function for a IntersectionController.
+ * The callback function for a `IntersectionController`.
  */
 export type IntersectionValueCallback = (
   ...args: Parameters<IntersectionObserverCallback>
 ) => unknown;
 
 /**
- * The config options for a IntersectionController.
+ * The config options for a `IntersectionController`.
  */
 export type IntersectionControllerConfig = IntersectionObserverInit & {
   /**
@@ -33,8 +33,8 @@ export type IntersectionControllerConfig = IntersectionObserverInit & {
 };
 
 /**
- * `IntersectionController` is a `ReactiveController` that integrates an `IntersectionObserver`
- * with a `ReactiveControllerHost`'s reactive update lifecycle.
+ * `IntersectionController` integrates an `IntersectionObserver` with a host element's reactive
+ * update lifecycle.
  *
  * This is can be used to detect when a target element "intersects" is visible inside of) another
  * element or the viewport by default, where intersect means "visible inside of."
@@ -67,8 +67,8 @@ export class IntersectionController implements ReactiveController {
 
   constructor(
     protected readonly _host: ReactiveControllerHost & EventTarget,
-    config: IntersectionControllerConfig,
-    protected readonly callback: IntersectionValueCallback = () => true,
+    config: IntersectionControllerConfig = {},
+    protected readonly _callback: IntersectionValueCallback = () => true,
     protected readonly _logger = __DEV__ ? new LogDispatcher(_host) : undefined
   ) {
     const { target, skipInitial, ...intersectionObserverInit } = config;
@@ -104,7 +104,7 @@ export class IntersectionController implements ReactiveController {
    * result stored in the `value` property.
    */
   protected handleChanges(entries: IntersectionObserverEntry[]) {
-    this.value = this.callback(entries, this._observer);
+    this.value = this._callback(entries, this._observer);
   }
 
   hostConnected() {

--- a/src/base/observers/IntersectionController.ts
+++ b/src/base/observers/IntersectionController.ts
@@ -1,0 +1,146 @@
+/**
+ * Adapted from: https://github.com/lit/lit/blob/main/packages/labs/observers/src/intersection_controller.ts
+ */
+
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+import { LogDispatcher } from '../logger';
+
+/**
+ * The callback function for a IntersectionController.
+ */
+export type IntersectionValueCallback = (
+  ...args: Parameters<IntersectionObserverCallback>
+) => unknown;
+
+/**
+ * The config options for a IntersectionController.
+ */
+export type IntersectionControllerConfig = IntersectionObserverInit & {
+  /**
+   * The element to observe. In addition to configuring the target here, the `observe` method
+   * can be called to observe additional targets. When not specified, the target defaults to
+   * the `host`. If set to `null`, no target is automatically observed. Only the configured
+   * target will be re-observed if the host connects again after unobserving via disconnection.
+   */
+  target?: Element | null;
+  /**
+   * An IntersectionObserver reports the initial intersection state when observe is called.
+   * Setting this flag to true skips processing this initial state for cases when this is
+   * unnecessary.
+   */
+  skipInitial?: boolean;
+};
+
+/**
+ * `IntersectionController` is a `ReactiveController` that integrates an `IntersectionObserver`
+ * with a `ReactiveControllerHost`'s reactive update lifecycle.
+ *
+ * This is can be used to detect when a target element "intersects" is visible inside of) another
+ * element or the viewport by default, where intersect means "visible inside of."
+ *
+ * The controller can specify a `target` element to observe and the configuration options to
+ * pass to the `IntersectionObserver`. The `observe` method can be called to observe
+ * additional elements.
+ *
+ * When a change is detected, the controller's given `callback` function is used to process the
+ * result into a value which is stored on the controller. The controller's `value` is usable
+ * during the host's update cycle.
+ */
+export class IntersectionController implements ReactiveController {
+  protected _target: Element | null;
+  protected _observer!: IntersectionObserver;
+  protected _skipInitial = false;
+
+  /**
+   * Flag used to help manage calling the `callback` when observe is called and `skipInitial` is
+   * set to true. Note that unlike the other observers `IntersectionObserver` *does* report its
+   * initial state (e.g. whether or not there is an intersection). This flag is used to avoid
+   * handling this state if `skipInitial` is true.
+   */
+  protected _unobservedUpdate = false;
+
+  /**
+   * The result of processing the observer's changes via the `callback` function.
+   */
+  value?: unknown;
+
+  constructor(
+    protected readonly _host: ReactiveControllerHost & EventTarget,
+    config: IntersectionControllerConfig,
+    protected readonly callback: IntersectionValueCallback = () => true,
+    protected readonly _logger = __DEV__ ? new LogDispatcher(_host) : undefined
+  ) {
+    const { target, skipInitial, ...intersectionObserverInit } = config;
+
+    this._target =
+      target === null ? target : target ?? (this._host as unknown as Element);
+
+    this._skipInitial = skipInitial ?? this._skipInitial;
+
+    if (!window.IntersectionObserver) {
+      if (__DEV__) {
+        _logger?.warn(`Browser does not support \`IntersectionObserver\`.`);
+      }
+      return;
+    }
+
+    this._observer = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        const unobservedUpdate = this._unobservedUpdate;
+        this._unobservedUpdate = false;
+        if (this._skipInitial && unobservedUpdate) return;
+        this.handleChanges(entries);
+        this._host.requestUpdate();
+      },
+      intersectionObserverInit
+    );
+
+    _host.addController(this);
+  }
+
+  /**
+   * Process the observer's changes with the controller's `callback` function to produce a
+   * result stored in the `value` property.
+   */
+  protected handleChanges(entries: IntersectionObserverEntry[]) {
+    this.value = this.callback(entries, this._observer);
+  }
+
+  hostConnected() {
+    if (this._target) {
+      this.observe(this._target);
+    }
+  }
+
+  hostDisconnected() {
+    this.disconnect();
+  }
+
+  async hostUpdated() {
+    // Eagerly deliver any changes that happened during update.
+    const pendingRecords = this._observer.takeRecords();
+    if (pendingRecords.length) {
+      this.handleChanges(pendingRecords);
+    }
+  }
+
+  /**
+   * Observe the target element. The controller's `target` is automatically observed when the
+   * host connects.
+   *
+   * @param target Element to observe
+   */
+  observe(target: Element) {
+    // This will always trigger the callback since the initial intersection state is reported.
+    this._observer.observe(target);
+    this._unobservedUpdate = true;
+  }
+
+  /**
+   * Disconnects the observer. This is done automatically when the host disconnects.
+   */
+  protected disconnect() {
+    this._observer.disconnect();
+  }
+}

--- a/src/base/observers/PageController.ts
+++ b/src/base/observers/PageController.ts
@@ -23,7 +23,7 @@ export type PageState = 'active' | 'passive' | 'hidden';
 /**
  * The current page visibility state.
  *
- * - **visible:** The page content may be at least partially visible. In practice this means that
+ * - **visible:** The page content may be at least partially visible. In practice, this means that
  * the page is the foreground tab of a non-minimized window.
  * - **hidden:** The page content is not visible to the user. In practice this means that the
  * document is either a background tab or part of a minimized window, or the OS screen lock is

--- a/src/base/observers/PageController.ts
+++ b/src/base/observers/PageController.ts
@@ -1,0 +1,164 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+import { DisposalBin, listen } from '../events';
+import { LogDispatcher } from '../logger/LogDispatcher';
+
+// Detect Safari to work around Safari-specific bugs.
+const IS_SAFARI =
+  // @ts-expect-error - `pushNotificaiton` type missing.
+  typeof window?.safari === 'object' && window?.safari.pushNotification;
+
+/**
+ * The current page state. Important to note we only account for a subset of page states, as
+ * the rest aren't valuable to the player at the moment.
+ *
+ * - **active:** A page is in the active state if it is visible and has input focus.
+ * - **passive:** A page is in the passive state if it is visible and does not have input focus.
+ * - **hidden:** A page is in the hidden state if it is not visible.
+ *
+ * @see https://developers.google.com/web/updates/2018/07/page-lifecycle-api#states
+ */
+export type PageState = 'active' | 'passive' | 'hidden';
+
+/**
+ * The current page visibility state.
+ *
+ * - **visible:** The page content may be at least partially visible. In practice this means that
+ * the page is the foreground tab of a non-minimized window.
+ * - **hidden:** The page content is not visible to the user. In practice this means that the
+ * document is either a background tab or part of a minimized window, or the OS screen lock is
+ * active.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
+ */
+export type PageVisibility = 'visible' | 'hidden';
+
+/**
+ * The callback function for a `PageController`. This is called when either the page
+ * state or visibility changes.
+ *
+ * @see {@link PageState}
+ * @see {@link PageVisibility}
+ */
+export type PageControllerCallback = ({
+  state: PageState,
+  visibility: PageVisibilityState
+}) => void;
+
+/**
+ * `PageController` detects page state or visibility changes for the life of the given `host`
+ * element.
+ *
+ * @see {@link PageState}
+ * @see {@link PageVisibility}
+ * @see https://developers.google.com/web/updates/2018/07/page-lifecycle-api
+ */
+export class PageController implements ReactiveController {
+  protected _state: PageState = this._determinePageState();
+  protected _visibility: PageVisibility = document.visibilityState;
+  protected _disposal = new DisposalBin();
+  protected _safariBeforeUnloadTimeout?: any;
+
+  get state(): PageState {
+    return this._state;
+  }
+
+  get visibility(): PageVisibility {
+    return this._visibility;
+  }
+
+  constructor(
+    protected readonly _host: ReactiveControllerHost & EventTarget,
+    protected readonly _callback: PageControllerCallback,
+    protected readonly _logger = __DEV__ ? new LogDispatcher(_host) : undefined
+  ) {
+    _host.addController(this);
+  }
+
+  hostConnected() {
+    const pageEvents = [
+      'focus',
+      'blur',
+      'visibilitychange',
+      'pageshow',
+      'pagehide'
+    ] as const;
+
+    this._state = this._determinePageState();
+    this._visibility = document.visibilityState;
+
+    pageEvents.forEach((pageEvent) => {
+      // @ts-expect-error - window event (not global).
+      const off = listen(window, pageEvent, this._handlePageEvent.bind(this));
+      this._disposal.add(off);
+    });
+
+    /**
+     * Safari does not reliably fire the `pagehide` or `visibilitychange` events when closing a
+     * tab, so we have to use `beforeunload` with a timeout to check whether the default action
+     * was prevented.
+     *
+     * We only add this to Safari because adding it to Firefox would prevent the page from being
+     * eligible for `bfcache`.
+     *
+     * @see https://bugs.webkit.org/show_bug.cgi?id=151610
+     * @see https://bugs.webkit.org/show_bug.cgi?id=151234
+     */
+    if (IS_SAFARI) {
+      this._disposal.add(
+        // @ts-expect-error - window event (not global).
+        listen(window, 'beforeunload', (event) => {
+          this._safariBeforeUnloadTimeout = setTimeout(() => {
+            if (!(event.defaultPrevented || event.returnValue.length > 0)) {
+              this._state = 'hidden';
+              this._visibility = 'hidden';
+              this._triggerCallback();
+            }
+          }, 0);
+        })
+      );
+    }
+  }
+
+  hostDisconnected() {
+    this._disposal.empty();
+  }
+
+  protected _handlePageEvent(event: Event) {
+    if (IS_SAFARI) {
+      window.clearTimeout(this._safariBeforeUnloadTimeout);
+    }
+
+    const prevState = this._state;
+    const prevVisibility = this._visibility;
+
+    // The `blur` event can fire while the page is being unloaded, so we
+    // only need to update the state if the current state is "active".
+    if (event.type !== 'blur' || this.state === 'active') {
+      this._state = this._determinePageState(event);
+      // The ternary condition is incase some browser implements other states such as `prerender`.
+      this._visibility =
+        document.visibilityState == 'hidden' ? 'hidden' : 'visible';
+    }
+
+    if (this.state !== prevState || this.visibility !== prevVisibility) {
+      this._triggerCallback();
+    }
+  }
+
+  protected _triggerCallback() {
+    this._callback({ state: this.state, visibility: this.visibility });
+  }
+
+  protected _determinePageState(event?: Event): PageState {
+    if (event?.type === 'blur' || document.visibilityState === 'hidden') {
+      return 'hidden';
+    }
+
+    if (document.hasFocus()) {
+      return 'active';
+    }
+
+    return 'passive';
+  }
+}

--- a/src/base/observers/index.ts
+++ b/src/base/observers/index.ts
@@ -1,0 +1,1 @@
+export * from './IntersectionController';

--- a/src/base/observers/index.ts
+++ b/src/base/observers/index.ts
@@ -1,1 +1,2 @@
 export * from './IntersectionController';
+export * from './PageController';

--- a/src/base/observers/intersection-controller.story.svelte
+++ b/src/base/observers/intersection-controller.story.svelte
@@ -20,7 +20,17 @@
         // skipInitial: false,
       },
       (entries) => {
-        eventCallback({ type: 'intersection', ...entries });
+        const logKeys = ['intersectionRatio', 'isIntersecting', 'isVisible'];
+
+        const values = logKeys.reduce(
+          (p, k) => ({ ...p, [k]: entries[0][k] }),
+          {}
+        );
+
+        eventCallback(
+          { type: 'intersection', timeStamp: Date.now(), ...values },
+          logKeys
+        );
       }
     );
 
@@ -34,31 +44,31 @@
     IntersectionObserverElement
   );
 
-  let left = 100;
-  let top = 100;
+  let left = 20;
+  let top = 20;
 
   let moving = false;
 
-  function onMouseDown() {
+  function onPointerDown() {
     moving = true;
   }
 
-  function onMouseMove(e) {
+  function onPointerMove(e) {
     if (moving) {
       left += e.movementX;
       top += e.movementY;
     }
   }
 
-  function onMouseUp() {
+  function onPointerUp() {
     moving = false;
   }
 </script>
 
-<svelte:window on:mouseup={onMouseUp} on:mousemove={onMouseMove} />
+<svelte:window on:pointerup={onPointerUp} on:pointermove={onPointerMove} />
 
 <vds-intersection-observer
-  on:mousedown={onMouseDown}
+  on:pointerdown={onPointerDown}
   style="left: {left}px; top: {top}px;"
 >
   <span class="drag-text">DRAG ME</span>
@@ -69,11 +79,12 @@
 <style>
   vds-intersection-observer {
     position: absolute;
-    user-select: none;
     cursor: move;
     width: 300px;
     height: 300px;
     background-color: orange;
+    user-select: none;
+    -webkit-user-select: none;
   }
 
   .drag-text {
@@ -85,5 +96,7 @@
     font-size: 24px;
     font-weight: bold;
     color: black;
+    user-select: none;
+    -webkit-user-select: none;
   }
 </style>

--- a/src/base/observers/intersection-controller.story.svelte
+++ b/src/base/observers/intersection-controller.story.svelte
@@ -7,7 +7,7 @@
 <script lang="ts">
   import { eventCallback, EventsAddon } from '@vitebook/client/addons';
 
-  import { LitElement } from 'lit';
+  import { html, LitElement } from 'lit';
   import { safelyDefineCustomElement } from '../../utils/dom';
   import { IntersectionController } from './IntersectionController';
 
@@ -23,6 +23,10 @@
         eventCallback({ type: 'intersection', ...entries });
       }
     );
+
+    override render() {
+      return html`<slot></slot>`;
+    }
   }
 
   safelyDefineCustomElement(
@@ -56,7 +60,9 @@
 <vds-intersection-observer
   on:mousedown={onMouseDown}
   style="left: {left}px; top: {top}px;"
-/>
+>
+  <span class="drag-text">DRAG ME</span>
+</vds-intersection-observer>
 
 <EventsAddon />
 
@@ -67,6 +73,17 @@
     cursor: move;
     width: 300px;
     height: 300px;
-    background-color: red;
+    background-color: orange;
+  }
+
+  .drag-text {
+    width: 300px;
+    height: 300px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    font-weight: bold;
+    color: black;
   }
 </style>

--- a/src/base/observers/intersection-controller.story.svelte
+++ b/src/base/observers/intersection-controller.story.svelte
@@ -1,0 +1,72 @@
+<script context="module">
+  export const __pageMeta = {
+    title: 'IntersectionController'
+  };
+</script>
+
+<script lang="ts">
+  import { eventCallback, EventsAddon } from '@vitebook/client/addons';
+
+  import { LitElement } from 'lit';
+  import { safelyDefineCustomElement } from '../../utils/dom';
+  import { IntersectionController } from './IntersectionController';
+
+  class IntersectionObserverElement extends LitElement {
+    controller = new IntersectionController(
+      this,
+      {
+        // rootMargin: null,
+        threshold: 1
+        // skipInitial: false,
+      },
+      (entries) => {
+        eventCallback({ type: 'intersection', ...entries });
+      }
+    );
+  }
+
+  safelyDefineCustomElement(
+    'vds-intersection-observer',
+    IntersectionObserverElement
+  );
+
+  let left = 100;
+  let top = 100;
+
+  let moving = false;
+
+  function onMouseDown() {
+    moving = true;
+  }
+
+  function onMouseMove(e) {
+    if (moving) {
+      left += e.movementX;
+      top += e.movementY;
+    }
+  }
+
+  function onMouseUp() {
+    moving = false;
+  }
+</script>
+
+<svelte:window on:mouseup={onMouseUp} on:mousemove={onMouseMove} />
+
+<vds-intersection-observer
+  on:mousedown={onMouseDown}
+  style="left: {left}px; top: {top}px;"
+/>
+
+<EventsAddon />
+
+<style>
+  vds-intersection-observer {
+    position: absolute;
+    user-select: none;
+    cursor: move;
+    width: 300px;
+    height: 300px;
+    background-color: red;
+  }
+</style>

--- a/src/base/observers/page-controller.story.svelte
+++ b/src/base/observers/page-controller.story.svelte
@@ -13,6 +13,13 @@
   import { PageController } from './PageController';
 
   class PageObserverElement extends LitElement {
+    protected _timeout;
+
+    override connectedCallback() {
+      super.connectedCallback();
+      this.style.backgroundColor = 'green';
+    }
+
     controller = new PageController(this, ({ state, visibility }) => {
       // TODO: work around below to show event details in events addon - fix in Vitebook later.
       const event = { type: 'change', state, visibility };
@@ -24,6 +31,11 @@
       });
 
       events.set(get(events));
+
+      window.clearTimeout(this._timeout);
+      this._timeout = setTimeout(() => {
+        this.style.backgroundColor = state === 'hidden' ? 'red' : 'green';
+      }, 300);
     });
   }
 
@@ -38,6 +50,5 @@
   vds-page-observer {
     width: 300px;
     height: 300px;
-    background-color: orange;
   }
 </style>

--- a/src/base/observers/page-controller.story.svelte
+++ b/src/base/observers/page-controller.story.svelte
@@ -1,0 +1,43 @@
+<script context="module">
+  export const __pageMeta = {
+    title: 'PageController'
+  };
+</script>
+
+<script lang="ts">
+  import { events, EventsAddon } from '@vitebook/client/addons';
+
+  import { LitElement } from 'lit';
+  import { get } from 'svelte/store';
+  import { safelyDefineCustomElement } from '../../utils/dom';
+  import { PageController } from './PageController';
+
+  class PageObserverElement extends LitElement {
+    controller = new PageController(this, ({ state, visibility }) => {
+      // TODO: work around below to show event details in events addon - fix in Vitebook later.
+      const event = { type: 'change', state, visibility };
+
+      get(events).unshift({
+        id: Symbol(),
+        ref: event as any,
+        stringify: () => JSON.stringify(event, null, 2)
+      });
+
+      events.set(get(events));
+    });
+  }
+
+  safelyDefineCustomElement('vds-page-observer', PageObserverElement);
+</script>
+
+<vds-page-observer />
+
+<EventsAddon />
+
+<style>
+  vds-page-observer {
+    width: 300px;
+    height: 300px;
+    background-color: orange;
+  }
+</style>

--- a/src/define/vds-media-sync.ts
+++ b/src/define/vds-media-sync.ts
@@ -1,0 +1,10 @@
+import { MediaSyncElement } from '../media/manage';
+import { safelyDefineCustomElement } from '../utils/dom';
+
+safelyDefineCustomElement('vds-media-sync', MediaSyncElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vds-media-sync': MediaSyncElement;
+  }
+}

--- a/src/define/vds-media-visibility.ts
+++ b/src/define/vds-media-visibility.ts
@@ -1,0 +1,10 @@
+import { MediaVisibilityElement } from '../media/manage';
+import { safelyDefineCustomElement } from '../utils/dom';
+
+safelyDefineCustomElement('vds-media-visibility', MediaVisibilityElement);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'vds-media-visibility': MediaVisibilityElement;
+  }
+}

--- a/src/global/types.ts
+++ b/src/global/types.ts
@@ -11,7 +11,9 @@ import type {
   MediaEvents,
   MediaPlayerConnectEvent,
   MediaProviderConnectEvent,
-  MediaRequestEvents
+  MediaRequestEvents,
+  MediaSyncEvents,
+  MediaVisibilityEvents
 } from '../media';
 import type { HlsEvents } from '../providers/hls';
 import type { VideoPresentationEvents } from '../providers/video';
@@ -27,6 +29,8 @@ declare global {
       HlsEvents,
       MediaEvents,
       MediaRequestEvents,
+      MediaVisibilityEvents,
+      MediaSyncEvents,
       ScreenOrientationEvents,
       ScrubberPreviewEvents,
       SliderEvents,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './base/elements';
 export * from './base/events';
 export * from './base/fullscreen';
 export * from './base/logger';
+export * from './base/observers';
 export * from './base/queue';
 export * from './base/screen-orientation';
 export * from './base/stores';

--- a/src/media/controller/MediaController.ts
+++ b/src/media/controller/MediaController.ts
@@ -82,9 +82,13 @@ export class MediaController {
     this._host,
     'vds-media-provider-connect',
     (event) => {
-      event.stopPropagation();
+      // @ts-expect-error - not typed.
+      if (event.detail.connected) return;
 
       const { element, onDisconnect } = event.detail;
+
+      // @ts-expect-error - not typed.
+      event.detail.connected = true;
 
       if (this.mediaProvider === element) return;
 

--- a/src/media/index.ts
+++ b/src/media/index.ts
@@ -2,6 +2,7 @@ export * from './CanPlay';
 export * from './controller';
 export * from './events';
 export * from './interact';
+export * from './manage';
 export * from './MediaContext';
 export * from './mediaStore';
 export * from './MediaType';

--- a/src/media/manage/MediaSyncElement.ts
+++ b/src/media/manage/MediaSyncElement.ts
@@ -1,0 +1,214 @@
+import debounce from 'just-debounce-it';
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import {
+  DisposalBin,
+  hostedEventListener,
+  listen,
+  vdsEvent
+} from '../../base/events';
+import type { VolumeChange, VolumeChangeEvent } from '../events';
+import type { MediaProviderElement } from '../provider';
+
+const mediaProviders = new Set<MediaProviderElement>();
+
+let syncingMediaPlayback = false;
+let syncingMediaVolume = false;
+
+/**
+ * This element is responsible for synchronizing elements of the type `MediaProviderElement`.
+ *
+ * Synchronization includes:
+ *
+ * - Shared media playback (eg: user plays a video while another is already playing, so we pause
+ * the newly inactive player).
+ *
+ * - Shared media volume (eg: user sets desired volume to 50% on one player, and they expect it to
+ * be consistent across all players).
+ *
+ * - Saving media volume to local storage (eg: user sets derived to volume 50%, they leave
+ * the site, and when they come back they expect it to be 50% without any interaction).
+ *
+ * @tagname vds-media-sync
+ * @slot - Used to pass in content, typically a media player/provider.
+ * @example
+ * ```html
+ * <vds-media-sync
+ *   shared-playback
+ *   shared-volume
+ *   volume-storage-key="@vidstack/volume"
+ * >
+ *   <!-- ... -->
+ * </vds-media-sync>
+ * ```
+ */
+export class MediaSyncElement extends LitElement {
+  /**
+   * Whether media playback is shared across players. This is so only one is playing at a time.
+   *
+   * @default false
+   */
+  @property({ type: Boolean, attribute: 'shared-playback' })
+  sharedPlayback = false;
+
+  /**
+   * Whether media volume should be in-sync across all media players.
+   *
+   * @default false
+   */
+  @property({ type: Boolean, attribute: 'shared-volume' })
+  sharedVolume = false;
+
+  /**
+   * If a value is provided, volume will be saved to local storage to the given key as it's
+   * updated. In addition, when a media provider connects to the manager, it's volume will be
+   * set to the saved volume level. If no value is provided, nothing is saved or retrieved.
+   *
+   * Note that this includes both the volume and muted state.
+   *
+   * @default undefined
+   */
+  @property({ attribute: 'volume-storage-key' })
+  volumeStorageKey?: string;
+
+  // -------------------------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------------------------
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._mediaProviderDisposal.empty();
+  }
+
+  override render() {
+    return html`<slot></slot>`;
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Media Provider Connect
+  // -------------------------------------------------------------------------------------------
+
+  protected _mediaProvider?: MediaProviderElement;
+  protected _mediaProviderDisposal = new DisposalBin();
+
+  get mediaProvider() {
+    return this._mediaProvider;
+  }
+
+  protected _handleMediaProviderConnect = hostedEventListener(
+    this,
+    'vds-media-provider-connect',
+    (event) => {
+      const { element, onDisconnect } = event.detail;
+
+      this._mediaProvider = element;
+      mediaProviders.add(element);
+
+      const savedVolume = this._getSavedMediaVolume();
+      if (savedVolume) {
+        this._mediaProvider.volume = savedVolume.volume;
+        this._mediaProvider.muted = savedVolume.muted;
+      }
+
+      if (this.sharedPlayback) {
+        const off = listen(
+          element,
+          'vds-play',
+          this._handleMediaPlay.bind(this)
+        );
+        this._mediaProviderDisposal.add(off);
+      }
+
+      if (this.sharedVolume) {
+        const off = listen(
+          element,
+          'vds-volume-change',
+          debounce(this._handleMediaVolumeChange.bind(this), 10, true)
+        );
+
+        this._mediaProviderDisposal.add(off);
+      }
+
+      if (this.volumeStorageKey) {
+        const off = listen(
+          element,
+          'vds-volume-change',
+          this._saveMediaVolume.bind(this)
+        );
+
+        this._mediaProviderDisposal.add(off);
+      }
+
+      this._mediaProviderDisposal.add(() => {
+        mediaProviders.delete(element);
+        this._mediaProvider = undefined;
+      });
+
+      onDisconnect(() => {
+        this._mediaProviderDisposal.empty();
+      });
+    }
+  );
+
+  // -------------------------------------------------------------------------------------------
+  // Playback
+  // -------------------------------------------------------------------------------------------
+
+  protected _handleMediaPlay() {
+    if (syncingMediaPlayback) return;
+
+    syncingMediaPlayback = true;
+
+    mediaProviders.forEach((provider) => {
+      if (provider !== this._mediaProvider) {
+        provider.paused = true;
+      }
+    });
+
+    syncingMediaPlayback = false;
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Volume
+  // -------------------------------------------------------------------------------------------
+
+  protected _handleMediaVolumeChange(event: VolumeChangeEvent) {
+    if (syncingMediaVolume) return;
+    syncingMediaVolume = true;
+
+    const { volume, muted } = event.detail;
+
+    mediaProviders.forEach((provider) => {
+      if (provider !== this._mediaProvider) {
+        provider.volume = volume;
+        provider.muted = muted;
+      }
+    });
+
+    this.dispatchEvent(
+      vdsEvent('vds-media-volume-sync', {
+        bubbles: true,
+        composed: true,
+        detail: event.detail
+      })
+    );
+
+    syncingMediaVolume = false;
+  }
+
+  protected _getSavedMediaVolume(): VolumeChange | undefined {
+    if (!this.volumeStorageKey) return;
+
+    try {
+      return JSON.parse(localStorage.getItem(this.volumeStorageKey)!);
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  protected _saveMediaVolume(event: VolumeChangeEvent) {
+    if (!this.volumeStorageKey) return;
+    localStorage.setItem(this.volumeStorageKey, JSON.stringify(event.detail));
+  }
+}

--- a/src/media/manage/MediaSyncElement.ts
+++ b/src/media/manage/MediaSyncElement.ts
@@ -27,7 +27,7 @@ let syncingMediaVolume = false;
  * - Shared media volume (eg: user sets desired volume to 50% on one player, and they expect it to
  * be consistent across all players).
  *
- * - Saving media volume to local storage (eg: user sets derived to volume 50%, they leave
+ * - Saving media volume to local storage (eg: user sets desired to volume 50%, they leave
  * the site, and when they come back they expect it to be 50% without any interaction).
  *
  * @tagname vds-media-sync

--- a/src/media/manage/MediaVisibilityElement.ts
+++ b/src/media/manage/MediaVisibilityElement.ts
@@ -1,0 +1,235 @@
+import { html, LitElement } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import { DisposalBin, hostedEventListener, vdsEvent } from '../../base/events';
+import { IntersectionController, PageController } from '../../base/observers';
+import type { MediaProviderElement } from '../provider';
+
+/**
+ * This element is responsible for managing a `MediaProviderElement` as viewport or page
+ * visibility changes occur.
+ *
+ * Management includes:
+ *
+ * - Playback or volume changes when page visibility changes (eg: user changes tab or device
+ * sleeps).
+ *
+ * - Playback or volume changes when viewport visibility changes (eg: user scrolls video in and
+ * out of view).
+ *
+ * @tagname vds-media-visibility
+ * @slot - Used to pass in content, typically a media player/provider.
+ * @example
+ * ```html
+ * <vds-media-visibility
+ *   on-enter="play"
+ *   on-exit="pause"
+ * >
+ *   <!-- ... -->
+ * </vds-media-visibility>
+ * ```
+ */
+export class MediaVisibilityElement extends LitElement {
+  /**
+   * The action to perform on the media provider when it becomes active by either entering
+   * the viewport, or the page becomes visible.
+   *
+   * @default undefined
+   */
+  @property({ attribute: 'on-enter' })
+  onEnter?: 'play' | 'unmute';
+
+  /**
+   * The action to perform on the media provider when it becomes inactive by either exiting
+   * the viewport, or the page becomes hidden.
+   *
+   * @default undefined
+   */
+  @property({ attribute: 'on-exit' })
+  onExit?: 'pause' | 'mute';
+
+  /**
+   * The type of page state to use when determining visibility.
+   *
+   * - **state:** Refers to the page lifecycle state. This is typically what you want.
+   * - **visibility:** Visible here means the page content may be at least partially visible. In
+   * practice, this means that the page is the foreground tab of a non-minimized window.
+   *
+   *💡 Need help making a decision?
+   *
+   * - Use `state` when you want completely visible / not visible.
+   * - Use `visibility` when you want partially visible / not visible.
+   *
+   * @default 'state'
+   */
+  @property({ attribute: 'page-change-type' })
+  pageChangeType: 'state' | 'visibility' = 'state';
+
+  /**
+   * A DOM query selector for the element that is used as the viewport for checking visibility
+   * of the media player. Must be a ancestor of the media player. Defaults to the browser viewport
+   * if not specified.
+   *
+   * @default undefined
+   */
+  @property({ attribute: 'intersection-root' })
+  intersectionRoot?: string;
+
+  /**
+   * A number which indicates at what percentage of the media player's visibility the observer's
+   * `onEnter` and `onExit` actions should be triggered.
+   *
+   * @default 1
+   */
+  @property({ type: Number, attribute: 'intersection-threshold' })
+  intersectionThreshold = 1;
+
+  // -------------------------------------------------------------------------------------------
+  // State
+  // -------------------------------------------------------------------------------------------
+
+  protected _isIntersecting = false;
+
+  get isIntersecting() {
+    return this._isIntersecting;
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------------------------
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._hasIntersected = false;
+    this._mediaProviderDisposal.empty();
+  }
+
+  override render() {
+    return html`<slot></slot>`;
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Media Provider Connect
+  // -------------------------------------------------------------------------------------------
+
+  protected _mediaProvider?: MediaProviderElement;
+  protected _mediaProviderDisposal = new DisposalBin();
+
+  get mediaProvider() {
+    return this._mediaProvider;
+  }
+
+  protected _handleMediaProviderConnect = hostedEventListener(
+    this,
+    'vds-media-provider-connect',
+    (event) => {
+      const { element, onDisconnect } = event.detail;
+
+      this._mediaProvider = element;
+
+      this._mediaProviderDisposal.add(() => {
+        this._mediaProvider = undefined;
+      });
+
+      onDisconnect(() => {
+        this._mediaProviderDisposal.empty();
+      });
+    }
+  );
+
+  // -------------------------------------------------------------------------------------------
+  // Observers
+  // -------------------------------------------------------------------------------------------
+
+  protected _hasIntersected = false;
+
+  protected intersectionController = new IntersectionController(
+    this,
+    {
+      root: this.intersectionRoot
+        ? document.querySelector(this.intersectionRoot)
+        : null,
+      threshold: this.intersectionThreshold
+    },
+    (entries) => {
+      const entry = entries[0];
+
+      this._isIntersecting = entry.isIntersecting;
+
+      // Skip first, we only want as we enter/exit viewport (not initial load).
+      if (this._hasIntersected) {
+        if (entry.isIntersecting) {
+          this._triggerOnEnter();
+        } else if (this.onExit) {
+          this._isIntersecting = false;
+          this._triggerOnExit();
+        }
+      }
+
+      this._hasIntersected = true;
+      this._dispatchVisibilityChange();
+    }
+  );
+
+  protected pageController = new PageController(
+    this,
+    ({ state, visibility }) => {
+      if (this.isIntersecting) {
+        const newState = this.pageChangeType === 'state' ? state : visibility;
+
+        if (newState === 'hidden') {
+          this._triggerOnExit();
+        } else if (this.onEnter) {
+          this._triggerOnEnter();
+        }
+      }
+
+      this._dispatchVisibilityChange();
+    }
+  );
+
+  // -------------------------------------------------------------------------------------------
+  // Triggers
+  // -------------------------------------------------------------------------------------------
+
+  protected _triggerOnEnter() {
+    if (!this._mediaProvider) return;
+
+    if (this.onEnter === 'play') {
+      this._mediaProvider.paused = false;
+    } else if (this.onEnter === 'unmute') {
+      this._mediaProvider.muted = false;
+    }
+  }
+
+  protected _triggerOnExit() {
+    if (!this._mediaProvider) return;
+
+    if (this.onExit === 'pause') {
+      this._mediaProvider.paused = true;
+    } else if (this.onExit === 'mute') {
+      this._mediaProvider.muted = true;
+    }
+  }
+
+  protected _dispatchVisibilityChange() {
+    if (!this._mediaProvider) return;
+
+    this.dispatchEvent(
+      vdsEvent('vds-media-visibility-change', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          provider: this._mediaProvider,
+          viewport: {
+            isIntersecting: this.isIntersecting
+          },
+          page: {
+            state: this.pageController.state,
+            visibility: this.pageController.visibility
+          }
+        }
+      })
+    );
+  }
+}

--- a/src/media/manage/events.ts
+++ b/src/media/manage/events.ts
@@ -1,0 +1,43 @@
+import type { VdsEvent } from '../../base/events';
+import type { PageState, PageVisibility } from '../../base/observers';
+import type { VolumeChange } from '../events';
+import type { MediaProviderElement } from '../provider';
+
+export type MediaVisibilityEvents = {
+  'vds-media-visibility-change': MediaVisibilityChangeEvent;
+};
+
+export type MediaVisibilityChange = {
+  /**
+   * The media provider element for which visibility has changed.
+   */
+  provider: MediaProviderElement;
+  /**
+   * Whether media is intersecting the configured viewport on the `MediaVisibilityElement`.
+   */
+  viewport: { isIntersecting: boolean };
+  /**
+   * The current page state and visibility.
+   */
+  page: { state: PageState; visibility: PageVisibility };
+};
+
+/**
+ * Fired when media visibility changes based on the viewport position or page visibility state.
+ *
+ * @bubbles
+ * @composed
+ */
+export type MediaVisibilityChangeEvent = VdsEvent<MediaVisibilityChange>;
+
+export type MediaSyncEvents = {
+  'vds-media-volume-sync': MediaVolumeSyncEvent;
+};
+
+/**
+ * Fired when media volume has been synchronized.
+ *
+ * @bubbles
+ * @composed
+ */
+export type MediaVolumeSyncEvent = VdsEvent<VolumeChange>;

--- a/src/media/manage/index.ts
+++ b/src/media/manage/index.ts
@@ -1,0 +1,3 @@
+export * from './events';
+export * from './MediaSyncElement';
+export * from './MediaVisibilityElement';

--- a/src/media/manage/media-sync.story.svelte
+++ b/src/media/manage/media-sync.story.svelte
@@ -1,0 +1,41 @@
+<script context="module">
+  export const __pageMeta = {
+    title: 'MediaSyncElement'
+  };
+</script>
+
+<script>
+  import { AudioElement } from '../../providers/audio';
+  import { safelyDefineCustomElement } from '../../utils/dom';
+  import { MediaSyncElement } from './MediaSyncElement';
+
+  safelyDefineCustomElement('vds-media-sync', MediaSyncElement);
+  safelyDefineCustomElement('vds-audio', AudioElement);
+</script>
+
+<div class="container">
+  {#each Array.from(Array(3)) as _}
+    <vds-media-sync
+      shared-playback
+      shared-volume
+      volume-storage-key="@vidstack/media-sync-story-volume"
+    >
+      <vds-audio src="https://media-files.vidstack.io/audio.mp3" controls />
+    </vds-media-sync>
+  {/each}
+</div>
+
+<style>
+  .container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  vds-media-sync {
+    margin-top: 40px;
+  }
+
+  vds-audio {
+    width: 375px;
+  }
+</style>

--- a/src/media/manage/media-visibility.story.svelte
+++ b/src/media/manage/media-visibility.story.svelte
@@ -1,0 +1,65 @@
+<script context="module">
+  export const __pageMeta = {
+    title: 'MediaVisibilityElement'
+  };
+</script>
+
+<script>
+  import { AudioElement } from '../../providers/audio';
+  import { safelyDefineCustomElement } from '../../utils/dom';
+  import { MediaVisibilityElement } from './MediaVisibilityElement';
+  import { Variant } from '@vitebook/client';
+  import { eventCallback, EventsAddon } from '@vitebook/client/addons';
+
+  safelyDefineCustomElement('vds-media-visibility', MediaVisibilityElement);
+  safelyDefineCustomElement('vds-audio', AudioElement);
+</script>
+
+<Variant name="Play/Pause">
+  <div class="container">
+    {#each Array.from(Array(5)) as _}
+      <vds-media-visibility
+        on-enter="play"
+        on-exit="pause"
+        on:vds-media-visibility-change={eventCallback}
+      >
+        <vds-audio src="https://media-files.vidstack.io/audio.mp3" controls />
+      </vds-media-visibility>
+    {/each}
+  </div>
+</Variant>
+
+<Variant name="Mute/Unmute">
+  <div class="container">
+    {#each Array.from(Array(5)) as _}
+      <vds-media-visibility
+        on-enter="unmute"
+        on-exit="mute"
+        on:vds-media-visibility-change={eventCallback}
+      >
+        <vds-audio src="https://media-files.vidstack.io/audio.mp3" controls />
+      </vds-media-visibility>
+    {/each}
+  </div>
+</Variant>
+
+<EventsAddon />
+
+<style>
+  .container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  vds-media-visibility {
+    margin-top: 100vh;
+  }
+
+  vds-media-visibility:first-child {
+    margin-top: 40vh;
+  }
+
+  vds-audio {
+    width: 375px;
+  }
+</style>

--- a/src/media/provider/MediaProviderElement.ts
+++ b/src/media/provider/MediaProviderElement.ts
@@ -266,10 +266,14 @@ export abstract class MediaProviderElement extends LitElement {
 
   set paused(shouldPause) {
     this.mediaRequestQueue.queue('paused', () => {
-      if (!shouldPause) {
-        this.play();
-      } else {
-        this.pause();
+      try {
+        if (!shouldPause) {
+          this.play();
+        } else {
+          this.pause();
+        }
+      } catch (e) {
+        this._logger?.error('paused-change-fail', e);
       }
 
       this.requestUpdate('paused');


### PR DESCRIPTION
Management includes:

- Page visibility changes (ie: user changes tab or device sleeps).
- Viewport visibility changes (ie: user scrolls video in and out of view).
- Shared playback (ie: user plays a video while another is already playing). 
- Shared volume (ie: user sets desired volume to 50% on one player and they expect it to be consistent across all players).

There’s different responsibilities being tackled here, so the best solution might be to build these out as controllers (eg: `PageVisibilityController`). These controllers could also be attached to a corresponding element such as `vds-media-manager`, or maybe `vds-page-manager`/`vds-viewport-manager` (if we want separate elements). 

## Changes

- **new:** `IntersectionController` for observing viewport intersection on a given `host` element.
- **new:** `PageController` for observing page state/visibility changes.
- **new:** `MediaSyncElement` for managing shared playback/volume between multiple media provider elements.
- **new:** `MediaVisibilityElement` for managing a media provider as viewport/page visibility changes.