### PR TITLE
Docs: media `ended` fix + example

### DIFF
--- a/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/replay.css
+++ b/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/replay.css
@@ -1,0 +1,41 @@
+vds-play-button {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    border-radius: 4px;
+    cursor: pointer;
+    color: white;
+  }
+  
+  vds-play-button > svg {
+    /** `absolute` so icons are placed on top of each other. */
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 1;
+    /* transition: opacity ease 150ms; */
+  }
+  
+  vds-media[paused] .media-pause-icon {
+    opacity: 0;
+  }
+  
+  vds-media:not([paused]):not([media-ended]) .media-play-icon {
+    opacity: 0;
+  } 
+  
+   vds-media[ended] .media-play-icon {
+      opacity: 0;
+  } 
+
+  /** Hide the media replay icon if media is not a the end */
+  vds-media:not([ended]) .media-replay-icon {
+      opacity: 0;
+  } 
+
+   /** show the media replay icon if media is at the end */
+  vds-media[ended] .media-replay-icon {
+      opacity: 1;
+  }

--- a/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/replay.html
+++ b/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/replay.html
@@ -1,0 +1,18 @@
+<vds-media>
+    <!-- ... -->
+    <vds-play-button>
+      <svg class="media-play-icon" aria-hidden="true" viewBox="0 0 24 24">
+        <path
+          fill="currentColor"
+          d="M19.376 12.416L8.777 19.482A.5.5 0 0 1 8 19.066V4.934a.5.5 0 0 1 .777-.416l10.599 7.066a.5.5 0 0 1 0 .832z"
+        />
+      </svg>
+      <svg class="media-pause-icon" aria-hidden="true" viewBox="0 0 24 24">
+        <path fill="currentColor" d="M6 5h2v14H6V5zm10 0h2v14h-2V5z" />
+      </svg>
+      <svg class="media-replay-icon" aria-hidden="true" viewBox="0 0 24 24">
+        <path  fill="currentColor"  d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"/>
+      </svg>
+    </vds-play-button>
+  </vds-media>
+  

--- a/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/replay.jsx
+++ b/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/replay.jsx
@@ -1,0 +1,26 @@
+import { Media, PlayButton } from '@vidstack/player-react';
+
+function MediaPlayer() {
+  return (
+    <Media>
+      {/* ... */}
+      <PlayButton>
+        <svg className="media-play-icon" aria-hidden="true" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M19.376 12.416L8.777 19.482A.5.5 0 0 1 8 19.066V4.934a.5.5 0 0 1 .777-.416l10.599 7.066a.5.5 0 0 1 0 .832z"
+          />
+        </svg>
+        <svg className="media-pause-icon" aria-hidden="true" viewBox="0 0 24 24">
+          <path fill="currentColor" d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />
+        </svg>
+        <svg className="media-replay-icon" aria-hidden="true" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"
+          />
+        </svg>
+      </PlayButton>
+    </Media>
+  );
+}

--- a/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/index.md
+++ b/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/index.md
@@ -19,3 +19,5 @@ Here's a simple styled `$tag:vds-play-button` example containing a play and paus
 You can extend the preview above by adding a replay SVG icon, and showing it whilst hiding the play icon
 when the `ended` attribute is present.
 {% /callout %}
+
+{% code_snippets name="replay" css=true copyHighlight=true highlight="html:13-15|css:34-41|react:17-19" /%}

--- a/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/index.md
+++ b/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/index.md
@@ -17,5 +17,5 @@ Here's a simple styled `$tag:vds-play-button` example containing a play and paus
 
 {% callout type="tip" %}
 You can extend the preview above by adding a replay SVG icon, and showing it whilst hiding the play icon
-when the `media-ended` attribute is present.
+when the `ended` attribute is present.
 {% /callout %}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "build:player-react": "turbo run build --filter=player-react",
     "build:player-svelte": "turbo run build --filter=player-svelte",
     "build:site": "turbo run build --filter=site",
+    "preview:site": "turbo run preview --filter=site",
+    "dev:site": "turbo run dev --filter=site",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s && node .scripts/fix-changelog.js",
     "lint": "turbo run lint --parallel",
     "test": "turbo run test --parallel",

--- a/turbo.json
+++ b/turbo.json
@@ -32,6 +32,8 @@
     },
     "test": {
       "dependsOn": ["^analyze", "^bundle"]
-    }
+    },
+    "preview": {},
+    "dev": {}
   }
 }


### PR DESCRIPTION
## **Is your Pull Request request related to another issue in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->

https://github.com/vidstack/player/issues/680

## **Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
- [x] Fixes `media-ended` to be `ended` in docs 
- [x] adds example for how to use a `replay` icon with `ended`.
- [x] Adds npm script to run vitebook dev and preview (using `pnpm` and turbo)

## **State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready
## **Additional context**    
<!-- Add any other context or screenshots about the PR. -->

_NA_
## **For Reviewers** 
<!-- Provide a checklist for reviewers of what you'd expect them to do to review this PR -->
Let me know if you'd prefer it without the example