### PR TITLE
docs(site): remove import code snippet for  buffering indicator a and controls page

### DIFF
--- a/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_import.svelte
+++ b/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_import.svelte
@@ -18,6 +18,10 @@
   import { comingSoonElement, elementTagName } from '$src/stores/element';
   import { jsLib } from '$src/stores/js-lib';
 
+  /* remove Import code snippets from buffering indicator and controls page */
+  const invalidElements = new Set(['vds-buffering-indicator', 'vds-controls']);
+  $: hideSnippets = invalidElements.has($elementTagName);
+
   $: js = [jsRawCode, jsHlsCode].map((s) => s.replace('{TAG_NAME}', $elementTagName));
   $: cdn = [cdnRawCode, cdnHlCode].map((s) => s.replace('{TAG_NAME}', $elementTagName));
   $: react = [reactRawCode, reactHlCode].map((s) =>

--- a/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_import.svelte
+++ b/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_import.svelte
@@ -31,9 +31,9 @@
 
 {#if $comingSoonElement}
   <p>This component is not available yet.</p>
-{:else if $jsLib === 'react'}
+{:else if !hideSnippets && $jsLib === 'react'}
   <CodeFence lang="tsx" code={react[0]} highlightedCode={react[1]} copy />
-{:else}
+{:else if !hideSnippets}
   <CodeFence lang="js" code={js[0]} highlightedCode={js[1]} copy />
   <CodeFence lang="html" title="cdn" code={cdn[0]} highlightedCode={cdn[1]} copy />
 {/if}

--- a/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_tabbed_links.svelte
+++ b/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_tabbed_links.svelte
@@ -9,9 +9,15 @@
   $: path = $route.url.pathname;
   $: docsHref = path.endsWith('/api.html') ? path.replace(/\/api\.html$/, '/') : path;
   $: apiHref = !path.includes('/api.html') ? `${path.replace(/\/$/, '')}/api.html` : path;
+
+  /* remove Import code snippets from buffering indicator and controls page */
+  const invalidElements = new Set(['vds-buffering-indicator', 'vds-controls']);
+  $: hideSnippets = invalidElements.has($elementTagName);
 </script>
 
 <TabbedLinks>
   <TabbedLink title="Docs" href={docsHref} />
-  <TabbedLink title="API" href={apiHref} disabled={$comingSoonElement} />
+  {#if !hideSnippets}
+    <TabbedLink title="API" href={apiHref} disabled={$comingSoonElement} />
+  {/if}
 </TabbedLinks>

--- a/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_tabbed_links.svelte
+++ b/apps/site/pages/docs/player/[lib]/[2]components/@markdoc/component_tabbed_links.svelte
@@ -10,7 +10,7 @@
   $: docsHref = path.endsWith('/api.html') ? path.replace(/\/api\.html$/, '/') : path;
   $: apiHref = !path.includes('/api.html') ? `${path.replace(/\/$/, '')}/api.html` : path;
 
-  /* remove Import code snippets from buffering indicator and controls page */
+  /* remove API Tab for buffering indicator and controls page */
   const invalidElements = new Set(['vds-buffering-indicator', 'vds-controls']);
   $: hideSnippets = invalidElements.has($elementTagName);
 </script>


### PR DESCRIPTION

## **Is your Pull Request request related to another issue in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
https://github.com/vidstack/player/issues/682
## **Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

Aims to remove import code snippet for  buffering indicator a and controls page

## **State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Not ready

## **Additional context**    
<!-- Add any other context or screenshots about the PR. -->
_NA_

## **For Reviewers** 
<!-- Provide a checklist for reviewers of what you'd expect them to do to review this PR -->

I did the change suggested in https://github.com/vidstack/player/issues/682#issuecomment-1304704202 but I don't see it when I run the preview of the site locally. Not sure I did the change correctly?


