### PR TITLE
docs(player): fix styling example page for Poster

### DIFF
--- a/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/styling.css
+++ b/apps/site/pages/docs/player/[lib]/[2]components/[3]ui/[7]play-button/_snippets/styling.css
@@ -1,7 +1,7 @@
 vds-play-button {
   position: relative;
-  width: 28px;
-  height: 28px;
+  width: 48px;
+  height: 48px;
   border-radius: 4px;
   cursor: pointer;
   color: white;


### PR DESCRIPTION
## **Is your Pull Request request related to another issue in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->

in the same space of https://github.com/vidstack/player/discussions/693 but not directly related

## **Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

Tiny PR to fix styling example page for [`Poster`](https://www.vidstack.io/docs/player/react/components/ui/poster/#styling)

## **State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

Ready 

## **Additional context**    
<!-- Add any other context or screenshots about the PR. -->
Before - you can't properly see the play icon
<img width="959" alt="Screen Shot 2022-11-16 at 10 12 03 AM" src="https://user-images.githubusercontent.com/4661975/202224379-e59104b3-896b-4c35-bf10-e3ea44dd197c.png">
After
<img width="953" alt="Screen Shot 2022-11-16 at 10 11 29 AM" src="https://user-images.githubusercontent.com/4661975/202224461-01e6995e-24cb-44ac-9556-be3505f0fde2.png">

## **For Reviewers** 
<!-- Provide a checklist for reviewers of what you'd expect them to do to review this PR -->
