### PR TITLE
fix(player): React `autoplay` prop can be `false`

### DIFF
--- a/packages/player/src/media/provider/MediaProviderElement.ts
+++ b/packages/player/src/media/provider/MediaProviderElement.ts
@@ -558,7 +558,9 @@ export abstract class MediaProviderElement extends LitElement {
       this.requestUpdate('autoplay', !newAutoplay);
     }
 
-    this._attemptAutoplay();
+    if (this.autoplay) {
+      this._attemptAutoplay();
+    }
   }
 
   protected _attemptingAutoplay = false;


### PR DESCRIPTION


## **Is your Pull Request request related to another issue in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
https://github.com/vidstack/player/discussions/695

## **Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->

Allows player `autoplay` value to be able to be `false`, for React Player, so that autoplay can be set as a prop.

## **State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready 
## **Additional context**    
<!-- Add any other context or screenshots about the PR. -->
_NA_

## **For Reviewers** 
<!-- Provide a checklist for reviewers of what you'd expect them to do to review this PR -->
💡 ?