### PR TITLE
Fix Spacebar double pausing on Safari

### DIFF
--- a/packages/vidstack/src/player/media/remote-control.ts
+++ b/packages/vidstack/src/player/media/remote-control.ts
@@ -210,6 +210,9 @@ export class MediaRemoteControl {
       return;
     }
 
+    // Prevent the event from bubbling up to default controls on safari/webkit.
+    trigger?.stopPropagation();
+
     if (player.state.paused) this.play(trigger);
     else this.pause(trigger);
   }


### PR DESCRIPTION
### Related:

Fixes https://github.com/vidstack/player/issues/788

### Description:

Fix spacebar pausing and unpausing on Safari and only does it once instead.

### Ready?

No.

### Anything Else?

Find fix on Chrome browsers and see if there are any problem with Firefox.

### Review Process:

Test on Safari, Chrome, and Firefox, as well as any browsers with planned support.
