### PR TITLE
fix: add isFinite check for pointer rate on slider-video

### DIFF
--- a/packages/vidstack/src/player/ui/slider-video/element.tsx
+++ b/packages/vidstack/src/player/ui/slider-video/element.tsx
@@ -33,7 +33,7 @@ export const SliderVideoDefinition = defineCustomElement<MediaSliderVideoElement
     });
 
     effect(() => {
-      if ($canPlay() && videoElement && Number.isFinite($media.duration)) {
+      if ($canPlay() && videoElement && Number.isFinite($media.duration) && Number.isFinite($slider.pointerRate)) {
         videoElement.currentTime = $slider.pointerRate * $media.duration;
       }
     });


### PR DESCRIPTION
### Description:

This PR adds a check for `$slider.pointerRate` to be finite in the slider-video component.

### Ready?

Yes, this PR is ready to be reviewed.

### Review Process:

Ensure "double value is non-finite" error is not observed again
