### PR TITLE
fix: Uncaught TypeError

### DIFF
--- a/packages/vidstack/src/player/media/tracks/text/render/native-text-renderer.ts
+++ b/packages/vidstack/src/player/media/tracks/text/render/native-text-renderer.ts
@@ -14,7 +14,8 @@ export class NativeTextRenderer implements TextRenderer {
     return true;
   }
 
-  attach(video: HTMLVideoElement) {
+  attach(video: HTMLVideoElement | null) {
+    if (!video) return;
     this._video = video;
     if (!video.crossOrigin) video.crossOrigin = 'anonymous';
     video.textTracks.onchange = this._onChange.bind(this);


### PR DESCRIPTION
Uncaught TypeError: Cannot read properties of null (reading 'crossOrigin') 

### Related:

https://github.com/vidstack/player/discussions/813

### Description:

Fixes the issue I've faced. Happens when components are destroyed (page changed on SvelteKit last version). See the screenshots.

### Ready?

Yep

### Anything Else?

![image](https://user-images.githubusercontent.com/49812531/233617845-9a5f06bb-3919-4cc6-a4b3-e949007aa547.png)
![image](https://user-images.githubusercontent.com/49812531/233617945-429c47a1-aa06-4d8a-a992-215b4c02c398.png)

### Review Process:

<!-- If possible, provide a checklist for what you'd expect us to do in order to review this PR. -->
