### PR TITLE
fix nullable current audio track with optional chain

### DIFF
--- a/packages/vidstack/src/player/media/providers/html/setup-events.ts
+++ b/packages/vidstack/src/player/media/providers/html/setup-events.ts
@@ -114,7 +114,7 @@ export function setupHTMLMediaElementEvents(
 
       audioTracks.addEventListener('change', (event) => {
         const { current } = event.detail;
-        const track = _tracks.getTrackById(current.id);
+        const track = _tracks.getTrackById(current?.id);
         if (track) {
           const prev = getEnabledAudioTrack();
           if (prev) prev.enabled = false;


### PR DESCRIPTION
### Related:
https://github.com/vidstack/player/issues/828

### Description:
Do a null check on current via optional chain.

### Ready?
Yep.

### Anything Else?

### Review Process:
Repro steps in issue above.
