### PR TITLE
fix: work around for webpack parse error.

### DIFF
--- a/packages/vidstack/styles/base.css
+++ b/packages/vidstack/styles/base.css
@@ -166,9 +166,8 @@
 }
 
 :where(media-time-slider) {
-  --media-buffered-percent: calc(
-    min(calc(var(--media-buffered) / max(var(--media-duration), 1)), 1) * 100%
-  );
+  --calc-min: min(calc(var(--media-buffered) / max(var(--media-duration), 1)), 1);
+  --media-buffered-percent: calc(var(--calc-min) * 100%);
 }
 
 :where(media-time-slider[data-chapters] > :not(shadow-root, [slot])),


### PR DESCRIPTION
### Description:

The integrated webpack in react 18 cannot parse the media-time-slider calculation:

```
postcss-calc:: Parse error on line 1: 
min(calc(var(--media-buffered) / max(var(--media-duration), 1)), 1) * 10...
--------------------------------------------------------------^
Expecting end of input, "ADD", "SUB", "MUL", "DIV", got unexpected "RPAREN" webpack://./node_modules/vidstack/styles/defaults.css:169:2
```

This change uses a temporary variable to work around this parsing problem.


### Ready?

Yes

### Anything Else?

n/a

### Review Process:

Confirm that the styles pass regression tests.  Our builds succeed with this change.
