### PR TITLE
fix: SCSS compilation with Dart SASS

### DIFF
--- a/packages/vidstack/styles/ui/menus.css
+++ b/packages/vidstack/styles/ui/menus.css
@@ -309,7 +309,7 @@
 }
 
 :where(media-menu [role='menuitem'][aria-hidden='true']),
-:where(media-menu [role='menuitem'][aria-expanded='true'] [slot='open-icon'], ) {
+:where(media-menu [role='menuitem'][aria-expanded='true'] [slot='open-icon'] ) {
   display: none !important;
 }
 


### PR DESCRIPTION
### Related:

<!-- If possible, link to other issues and PRs as appropriate. -->

### Description:

I'm using this library with Hugo's built-in SCSS capabilities (in Dart SASS mode to support the latest features), however it complained about a missing selector in `menus.css` file. When I opened it in the IDE, even that was showing a syntax error where I have made the changes. This PR should fix that issue.

While I understand a new version is being shipped, it would be useful if this PR is merged and released while the docs for the new version are prepared.

### Ready?

Yes

### Anything Else?
No

### Review Process:

Simply removing an extra comma, nothing much to review here
