### PR TITLE
Add support for nested sandbox environments per package

### DIFF
--- a/.scripts/sandbox-build.js
+++ b/.scripts/sandbox-build.js
@@ -1,0 +1,14 @@
+import { $ } from 'execa';
+
+const key = process.env.npm_lifecycle_event;
+const target = key.split(':');
+
+async function main() {
+  $`vite build ${target.join('/')}`;
+}
+
+main().catch((e) => {
+  if (e.exitCode === 1) return;
+  console.error(e);
+  process.exit(1);
+});

--- a/.scripts/sandbox.js
+++ b/.scripts/sandbox.js
@@ -4,14 +4,17 @@ import path from 'path';
 import { execa } from 'execa';
 
 const __cwd = process.cwd();
+const key = process.env.npm_lifecycle_event;
+const target = key.split(':');
 
 async function main() {
-  const SANDBOX_DIR = path.resolve(__cwd, 'sandbox');
+  const ROOT_SANDBOX_DIR = path.resolve(__cwd, 'sandbox');
+  const SANDBOX_DIR = path.resolve(ROOT_SANDBOX_DIR, `sandbox/${target[1] ?? ''}`);
   const SANDBOX_SERVER_FILE = path.resolve(SANDBOX_DIR, 'server.js');
   const SANDBOX_NODE_MODULES = path.resolve(SANDBOX_DIR, 'node_modules');
   const SANDBOX_PKG = path.resolve(SANDBOX_DIR, 'package.json');
 
-  if (!fs.existsSync(SANDBOX_DIR)) {
+  if (!fs.existsSync(ROOT_SANDBOX_DIR)) {
     await execa(
       'node',
       [
@@ -25,13 +28,13 @@ async function main() {
   }
 
   if (fs.existsSync(SANDBOX_PKG) && !fs.existsSync(SANDBOX_NODE_MODULES)) {
-    await execa('pnpm', ['-C', 'sandbox', 'i'], { stdio: 'inherit' });
+    await execa('pnpm', ['-C', key, 'i'], { stdio: 'inherit' });
   }
 
   if (fs.existsSync(SANDBOX_SERVER_FILE)) {
     await execa('node', [SANDBOX_SERVER_FILE], { stdio: 'inherit' });
   } else {
-    await execa('vite', ['--open=/sandbox/index.html', '--port=3100', '--host'], {
+    await execa('vite', [`--open=/${target.join('/')}/index.html`, '--port=3100', '--host'], {
       stdio: 'inherit',
     });
   }


### PR DESCRIPTION
### Related:

N/A

### Description:

Lets us create different sandbox environments per package. Sandbox directory might look something like this 

```
/packages
   /some-package
      /sandbox
         /react
            index.html
            main.tsx
         /svelte
           index.html
           main.svelte
         index.html
         main.ts
```

Then we can add scripts like

```
pnpm run sandbox
pnpm run sandbox:build

pnpm run sandbox:react
pnpm run sandbox:build:react

pnpm run sandbox:svelte
pnpm run sandbox:build:svelte
```

### Ready?

Not yet. Adding templates.

### Anything Else?

N/A

### Review Process:

N/A
