### PR TITLE
fix vimeo loader file type error

### DIFF
--- a/packages/vidstack/src/providers/vimeo/loader.ts
+++ b/packages/vidstack/src/providers/vimeo/loader.ts
@@ -54,7 +54,7 @@ export class VimeoProviderLoader implements MediaProviderLoader<VimeoProvider> {
 
     const { videoId } = resolveVimeoVideoId(src.src);
     if (videoId) {
-      return getVimeoVideoInfo(videoId, abort).then((info) => info.poster);
+      return getVimeoVideoInfo(videoId, abort).then((info) => (info ? info.poster : null));
     }
 
     return null;


### PR DESCRIPTION


### Description:

When I tried to start the project it gave me an error related to `/packages/vidstack/src/providers/vimeo/loader.ts` file that `info` is `undefined` so I opened the file and saw the ts error that says `'info' is possibly 'undefined'`. This error prevents the project  to start.

### Ready?

Yes

### Anything Else?

![image](https://github.com/vidstack/player/assets/63015240/5e01a9a4-477b-4171-b698-0b1cf7c4dd22)



