### PR TITLE
fix: expected selector

### DIFF
--- a/packages/vidstack/player/styles/default/layouts/video.css
+++ b/packages/vidstack/player/styles/default/layouts/video.css
@@ -388,7 +388,7 @@
     .vds-slider:not(.vds-time-slider),
     .vds-time,
     .vds-time-divider,
-    .vds-chapter-title,
+    .vds-chapter-title
 
   ) {
   transition: opacity 0.15s ease;


### PR DESCRIPTION
### Description:

Using SCSS to transform CSS fails with the error: `failed to transform "css/bundle.scss" (text/x-scss): "/<project>/node_modules/vidstack/player/styles/default/layouts/video.css:410:23": expected selector`. This PR fixes it by removing an extra `,`. This is currently happening in `1.10.3`. I was last using `1.9.8` which didn't have this issue.

### Ready?

Yes

### Review Process:

It simply removes an extra `,` from the CSS, so there shouldn't be any significant issues.
