### PR TITLE
fix(player/react): poster showing broken image icon on load

### DIFF
--- a/packages/react/src/components/ui/poster.tsx
+++ b/packages/react/src/components/ui/poster.tsx
@@ -66,10 +66,12 @@ interface PosterImgProps {
 
 const PosterImg = React.forwardRef<HTMLImageElement, PosterImgProps>(
   ({ instance, children, ...props }, forwardRef) => {
-    const { src, img, alt, crossOrigin } = instance.$state,
+    const { src, img, alt, crossOrigin, loading, hidden } = instance.$state,
       $src = useSignal(src),
       $alt = useSignal(alt),
-      $crossOrigin = useSignal(crossOrigin);
+      $crossOrigin = useSignal(crossOrigin),
+      $loading = useSignal(loading),
+      $hidden = useSignal(hidden);
     return (
       <Primitive.img
         {...props}
@@ -77,6 +79,7 @@ const PosterImg = React.forwardRef<HTMLImageElement, PosterImgProps>(
         alt={$alt || undefined}
         crossOrigin={$crossOrigin || undefined}
         ref={composeRefs(img.set as any, forwardRef)}
+        style={{ display: $loading || $hidden ? 'none' : undefined }}
       >
         {children}
       </Primitive.img>


### PR DESCRIPTION
### Related:

#1143

### Description:

The fix in https://github.com/vidstack/player/commit/2684fc3949ace4dc2bd899d47d693d921c026c41 was only targeting the base Vidstack package, I quickly ported it over to the React package.

### Ready?

Yes
