### PR TITLE
fix(player): add workerd to node exports

### DIFF
--- a/packages/vidstack/package.json
+++ b/packages/vidstack/package.json
@@ -104,6 +104,7 @@
       "node": "./dist/server/vidstack.js",
       "deno": "./dist/server/vidstack.js",
       "bun": "./dist/server/vidstack.js",
+      "workerd": "./dist/server/vidstack.js",
       "development": "./dist/dev/vidstack.js",
       "default": "./dist/prod/vidstack.js"
     },
@@ -112,6 +113,7 @@
       "node": "./dist/server/vidstack-elements.js",
       "deno": "./dist/server/vidstack-elements.js",
       "bun": "./dist/server/vidstack-elements.js",
+      "workerd": "./dist/server/vidstack-elements.js",
       "development": "./dist/dev/vidstack-elements.js",
       "default": "./dist/prod/vidstack-elements.js"
     },
@@ -120,6 +122,7 @@
       "node": "./dist/server/define/vidstack-icons.js",
       "deno": "./dist/server/define/vidstack-icons.js",
       "bun": "./dist/server/define/vidstack-icons.js",
+      "workerd": "./dist/server/define/vidstack-icons.js",
       "development": "./dist/dev/define/vidstack-icons.js",
       "default": "./dist/prod/define/vidstack-icons.js"
     },
@@ -128,6 +131,7 @@
       "node": "./dist/server/define/vidstack-player.js",
       "deno": "./dist/server/define/vidstack-player.js",
       "bun": "./dist/server/define/vidstack-player.js",
+      "workerd": "./dist/server/define/vidstack-player.js",
       "development": "./dist/dev/define/vidstack-player.js",
       "default": "./dist/prod/define/vidstack-player.js"
     },
@@ -136,6 +140,7 @@
       "node": "./dist/server/define/vidstack-player-ui.js",
       "deno": "./dist/server/define/vidstack-player-ui.js",
       "bun": "./dist/server/define/vidstack-player-ui.js",
+      "workerd": "./dist/server/define/vidstack-player-ui.js",
       "development": "./dist/dev/define/vidstack-player-ui.js",
       "default": "./dist/prod/define/vidstack-player-ui.js"
     },
@@ -144,6 +149,7 @@
       "node": "./dist/server/define/vidstack-player-layouts.js",
       "deno": "./dist/server/define/vidstack-player-layouts.js",
       "bun": "./dist/server/define/vidstack-player-layouts.js",
+      "workerd": "./dist/server/define/vidstack-player-layouts.js",
       "development": "./dist/dev/define/vidstack-player-layouts.js",
       "default": "./dist/prod/define/vidstack-player-layouts.js"
     },
@@ -152,6 +158,7 @@
       "node": "./dist/server/define/vidstack-player-default-layout.js",
       "deno": "./dist/server/define/vidstack-player-default-layout.js",
       "bun": "./dist/server/define/vidstack-player-default-layout.js",
+      "workerd": "./dist/server/define/vidstack-player-default-layout.js",
       "development": "./dist/dev/define/vidstack-player-default-layout.js",
       "default": "./dist/prod/define/vidstack-player-default-layout.js"
     },
@@ -160,6 +167,7 @@
       "node": "./dist/server/define/vidstack-player-plyr-layout.js",
       "deno": "./dist/server/define/vidstack-player-plyr-layout.js",
       "bun": "./dist/server/define/vidstack-player-plyr-layout.js",
+      "workerd": "./dist/server/define/vidstack-player-plyr-layout.js",
       "development": "./dist/dev/define/vidstack-player-plyr-layout.js",
       "default": "./dist/prod/define/vidstack-player-plyr-layout.js"
     },


### PR DESCRIPTION
### Related:

Similair to #1196 but now it's for Cloudflare Workers/Pages instead of Deno.

### Description:

Adds the `workerd` key to the packages conditional exports, so Cloudflare Workers will use the server bundle.

Before it was using the browser bundle which broke my Nuxt 3 site when server-side rendering the Vidstack player.

I've tried to just 1-to-1 matches the changes made for Bun and Deno yesterday.

### Ready?

Yes.

### Anything Else?

[Cloudflare's docs on the `workerd` exports key](https://developers.cloudflare.com/workers/wrangler/bundling/#conditional-exports)

### Review Process:

- [ ] Clone reproduction from [Altinget/nuxt-vidstack-reproduction](https://github.com/Altinget/nuxt-vidstack-reproduction)
- [ ] Install packages with `npm i`
- [ ] Build project and run it locally via Cloudflare's Wrangler CLI with `npm run build && npx wrangler pages dev dist/`

Before the change it fails like so:
![image](https://github.com/vidstack/player/assets/8006105/abb660ca-b3d4-4dc3-83f3-4e6f741518b2)

After the change it instead starts the server and you can go to [http://localhost:8788/other-page](http://localhost:8788/other-page) and it loads without throwing any errors.
