### PR TITLE
Replace small percent sign with normal one for slider values

### DIFF
--- a/packages/vidstack/src/components/ui/sliders/slider-value.ts
+++ b/packages/vidstack/src/components/ui/sliders/slider-value.ts
@@ -56,7 +56,7 @@ export class SliderValue extends Component<SliderValueProps> {
     if (_format === 'percent') {
       const range = max() - min();
       const percent = (value / range) * 100;
-      return (this._format.percent ?? round)(percent, decimalPlaces()) + '﹪';
+      return (this._format.percent ?? round)(percent, decimalPlaces()) + '%';
     } else if (_format === 'time') {
       return (this._format.time ?? formatTime)(value, {
         padHrs: padHours(),


### PR DESCRIPTION
### Description:

Almost the whole player uses the normal percent sign `%` (U+0025) to display percentages.

Except for the `SliderValue` component in which the small percent sign `﹪` (U+FE6A) is used.

Since this character isn't available in many fonts it may look kind of weird:
![image](https://github.com/vidstack/player/assets/43130816/90d03eae-149c-4f82-acb2-50f88d56b07a)

For consistency and better font compatibility also just the default percent sign should be used:
![image](https://github.com/vidstack/player/assets/43130816/297eb23e-0337-4bd9-a7be-24ba9de5ca5b)

### Ready?

Yes
