### PR TITLE
Fix: Center Poster Image

### DIFF
--- a/packages/vidstack/player/styles/default/poster.css
+++ b/packages/vidstack/player/styles/default/poster.css
@@ -8,7 +8,8 @@
   display: block;
   contain: content;
   position: absolute;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
   left: 0;
   opacity: 0;
   width: 100%;


### PR DESCRIPTION
### Related:

<!-- If possible, link to other issues and PRs as appropriate. -->

### Description:

I noticed that the poster image displayed before the video plays was not correctly centered (vertically), causing it to appear misaligned, especially on larger screens or within specific container dimensions. This misalignment detracts from the user's initial interaction with the video player.

### Ready?

Yes.

### Anything Else?

https://www.loom.com/share/29ebae2a91054ca9968172c850a40e68

### Review Process:

<!-- If possible, provide a checklist for what you'd expect us to do in order to review this PR. -->
