### PR TITLE
Store disabled captions configuration in LocalStorage.

### DIFF
--- a/packages/vidstack/mangle.json
+++ b/packages/vidstack/mangle.json
@@ -866,5 +866,6 @@
   "_parseContent": "ap",
   "_onEndPrecisionChange": "fp",
   "_setAudioGain": "gp",
-  "_updateColorScheme": "hp"
+  "_updateColorScheme": "hp",
+  "_pendingRemoval": "ip"
 }

--- a/packages/vidstack/src/core/tracks/text/text-tracks.ts
+++ b/packages/vidstack/src/core/tracks/text/text-tracks.ts
@@ -140,7 +140,7 @@ export class TextTrackList extends List<TextTrack, TextTrackListEvents> {
   private _onTrackModeChange(event: TextTrackModeChangeEvent) {
     const track = event.detail;
 
-    if (this._storage && isTrackCaptionKind(track) && track.mode !== 'disabled') {
+    if (this._storage && isTrackCaptionKind(track)) {
       this._saveCaptionsTrack(track);
     }
 
@@ -162,7 +162,9 @@ export class TextTrackList extends List<TextTrack, TextTrackListEvents> {
   }
 
   private _saveCaptionsTrack(track: TextTrack) {
-    this._saveLang(track.language);
+    if (track.mode !== 'disabled') {
+      this._saveLang(track.language);
+    }
     this._storage?.setCaptions?.(track.mode === 'showing');
   }
 

--- a/packages/vidstack/src/core/tracks/text/text-tracks.ts
+++ b/packages/vidstack/src/core/tracks/text/text-tracks.ts
@@ -69,12 +69,14 @@ export class TextTrackList extends List<TextTrack, TextTrackListEvents> {
   }
 
   remove(track: TextTrack, trigger?: Event) {
+    this._pendingRemoval = track;
     if (!this._items.includes(track)) return;
     if (track === this._defaults[track.kind]) delete this._defaults[track.kind];
     track.mode = 'disabled';
     track[TextTrackSymbol._onModeChange] = null;
     track.removeEventListener('mode-change', this._onTrackModeChangeBind);
     this[ListSymbol._remove](track, trigger);
+    this._pendingRemoval = null;
     return this;
   }
 
@@ -136,11 +138,13 @@ export class TextTrackList extends List<TextTrack, TextTrackListEvents> {
     }
   }, 300);
 
+  private _pendingRemoval: TextTrack | null = null;
   private _onTrackModeChangeBind = this._onTrackModeChange.bind(this);
   private _onTrackModeChange(event: TextTrackModeChangeEvent) {
     const track = event.detail;
 
-    if (this._storage && isTrackCaptionKind(track)) {
+    // We need to check whether track is being removed to not mistakenly save "disabled" mode change.
+    if (this._storage && isTrackCaptionKind(track) && track !== this._pendingRemoval) {
       this._saveCaptionsTrack(track);
     }
 


### PR DESCRIPTION
### Related:

<!-- If possible, link to other issues and PRs as appropriate. -->

(Hopefully) fixes: https://github.com/vidstack/player/issues/1234

### Description:

When a captions text track changes to `mode = 'disabled'`, we don't update the `captions: true` flag in LocalStorage to `false`. That means that the enable/disable captions setting is not persisted correctly and isn't carried over when the website refreshes. So, the user has to disable the captions again after every page refresh.

<!-- A clear and concise description of what the PR does. -->

### Ready?

<!-- Is this PR ready to be reviewed? -->

Yes, I think so. I couldn't test it locally though (I'm not a JS developer and have no clue how, sorry!)

### Anything Else?

<!-- Links? References? Screenshots? Anything that will give us more context about the PR. -->

### Review Process:

<!-- If possible, provide a checklist for what you'd expect us to do in order to review this PR. -->
