### PR TITLE
Improved DASH audio/text track labels

### DIFF
--- a/packages/vidstack/src/utils/language.ts
+++ b/packages/vidstack/src/utils/language.ts
@@ -1,0 +1,16 @@
+/**
+ * Gets the language name corresponding to the provided language code.
+ *
+ * @param {string} langCode - The language code (e.g.,"en", "en-us", "es-es", "fr-fr").
+ * @returns {string} The localized language name based on the user's preferred languages,
+ *                   or `null` if the language code is not recognized.
+ */
+export function getLangName(langCode: string) {
+  try {
+    const displayNames = new Intl.DisplayNames(navigator.languages, { type: 'language' });
+    const languageName = displayNames.of(langCode);
+    return languageName ?? null;
+  } catch (err) {
+    return null;
+  }
+}


### PR DESCRIPTION
### Description:

If no labels are provided, then `track.lang` is chosen as a fallback. Instead, we can use [Intl.DisplayNames](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DisplayNames#language_display_names) to get the name of the language by using the language code.


### Ready?
yes

### Before
![before](https://github.com/vidstack/player/assets/69267018/4ff09445-2140-4c2f-9f56-75a93bedc217)

### After
![after](https://github.com/vidstack/player/assets/69267018/124b8ccd-5d24-4c98-b360-128504767687)
