### PR TITLE
feat(player/react): add default layout slots for settings sub-menus

### DIFF
--- a/packages/react/src/components/layouts/default/slots.tsx
+++ b/packages/react/src/components/layouts/default/slots.tsx
@@ -47,17 +47,17 @@ export type DefaultLayoutSlotName =
 export type DefaultLayoutMenuSlotName =
   | 'chaptersMenu'
   | 'settingsMenu'
-  | 'settingsMenuStartItems'
-  | 'settingsMenuEndItems'
-  | 'playbackSettingsMenuStartItems'
-  | 'playbackSettingsMenuEndItems'
+  | 'settingsMenuItemsStart'
+  | 'settingsMenuItemsEnd'
+  | 'playbackSettingsMenuItemsStart'
+  | 'playbackSettingsMenuItemsEnd'
   | 'playbackSettingsMenuLoop'
-  | 'accessibilitySettingsMenuStartItems'
-  | 'accessibilitySettingsMenuEndItems'
-  | 'audioSettingsMenuStartItems'
-  | 'audioSettingsMenuEndItems'
-  | 'captionsMenuStartItems'
-  | 'captionsMenuEndItems';
+  | 'accessibilitySettingsMenuItemsStart'
+  | 'accessibilitySettingsMenuItemsEnd'
+  | 'audioSettingsMenuItemsStart'
+  | 'audioSettingsMenuItemsEnd'
+  | 'captionsMenuItemsStart'
+  | 'captionsMenuItemsEnd';
 
 export interface DefaultLayoutSlots extends Slots<DefaultLayoutSlotName> {}
 

--- a/packages/react/src/components/layouts/default/slots.tsx
+++ b/packages/react/src/components/layouts/default/slots.tsx
@@ -48,7 +48,16 @@ export type DefaultLayoutMenuSlotName =
   | 'chaptersMenu'
   | 'settingsMenu'
   | 'settingsMenuStartItems'
-  | 'settingsMenuEndItems';
+  | 'settingsMenuEndItems'
+  | 'playbackSettingsMenuStartItems'
+  | 'playbackSettingsMenuEndItems'
+  | 'playbackSettingsMenuLoop'
+  | 'accessibilitySettingsMenuStartItems'
+  | 'accessibilitySettingsMenuEndItems'
+  | 'audioSettingsMenuStartItems'
+  | 'audioSettingsMenuEndItems'
+  | 'captionsMenuStartItems'
+  | 'captionsMenuEndItems';
 
 export interface DefaultLayoutSlots extends Slots<DefaultLayoutSlotName> {}
 

--- a/packages/react/src/components/layouts/default/slots.tsx
+++ b/packages/react/src/components/layouts/default/slots.tsx
@@ -47,15 +47,19 @@ export type DefaultLayoutSlotName =
 export type DefaultLayoutMenuSlotName =
   | 'chaptersMenu'
   | 'settingsMenu'
+  /** @deprecated - use `settingsMenuItemsStart` */
+  | 'settingsMenuStartItems'
+  /** @deprecated - use `settingsMenuItemsEnd` */
+  | 'settingsMenuEndItems'
   | 'settingsMenuItemsStart'
   | 'settingsMenuItemsEnd'
-  | 'playbackSettingsMenuItemsStart'
-  | 'playbackSettingsMenuItemsEnd'
-  | 'playbackSettingsMenuLoop'
-  | 'accessibilitySettingsMenuItemsStart'
-  | 'accessibilitySettingsMenuItemsEnd'
-  | 'audioSettingsMenuItemsStart'
-  | 'audioSettingsMenuItemsEnd'
+  | 'playbackMenuItemsStart'
+  | 'playbackMenuItemsEnd'
+  | 'playbackMenuLoop'
+  | 'accessibilityMenuItemsStart'
+  | 'accessibilityMenuItemsEnd'
+  | 'audioMenuItemsStart'
+  | 'audioMenuItemsEnd'
   | 'captionsMenuItemsStart'
   | 'captionsMenuItemsEnd';
 

--- a/packages/react/src/components/layouts/default/ui/menus/accessibility-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/accessibility-menu.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useMediaState } from '../../../../../hooks/use-media-state';
 import * as Menu from '../../../../ui/menu';
 import { useDefaultLayoutContext, useDefaultLayoutWord } from '../../context';
+import { slot, type DefaultLayoutMenuSlotName, type Slots } from '../../slots';
 import { DefaultFontMenu } from './font-menu';
 import { DefaultMenuCheckbox } from './items/menu-checkbox';
 import { DefaultMenuButton, DefaultMenuItem, DefaultMenuSection } from './items/menu-items';
@@ -11,7 +12,11 @@ import { DefaultMenuButton, DefaultMenuItem, DefaultMenuSection } from './items/
  * DefaultAccessibilityMenu
  * -----------------------------------------------------------------------------------------------*/
 
-function DefaultAccessibilityMenu() {
+interface DefaultAccessibilityMenuProps {
+  slots?: Slots<DefaultLayoutMenuSlotName>;
+}
+
+function DefaultAccessibilityMenu({ slots }: DefaultAccessibilityMenuProps) {
   const label = useDefaultLayoutWord('Accessibility'),
     { icons: Icons } = useDefaultLayoutContext();
 
@@ -19,6 +24,8 @@ function DefaultAccessibilityMenu() {
     <Menu.Root className="vds-accessibility-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Accessibility} />
       <Menu.Content className="vds-menu-items">
+        {slot(slots, 'accessibilitySettingsMenuStartItems', null)}
+
         <DefaultMenuSection>
           <DefaultAnnouncementsMenuCheckbox />
           <DefaultKeyboardAnimationsMenuCheckbox />
@@ -27,6 +34,8 @@ function DefaultAccessibilityMenu() {
         <DefaultMenuSection>
           <DefaultFontMenu />
         </DefaultMenuSection>
+
+        {slot(slots, 'accessibilitySettingsMenuEndItems', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/accessibility-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/accessibility-menu.tsx
@@ -24,7 +24,7 @@ function DefaultAccessibilityMenu({ slots }: DefaultAccessibilityMenuProps) {
     <Menu.Root className="vds-accessibility-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Accessibility} />
       <Menu.Content className="vds-menu-items">
-        {slot(slots, 'accessibilitySettingsMenuItemsStart', null)}
+        {slot(slots, 'accessibilityMenuItemsStart', null)}
 
         <DefaultMenuSection>
           <DefaultAnnouncementsMenuCheckbox />
@@ -35,7 +35,7 @@ function DefaultAccessibilityMenu({ slots }: DefaultAccessibilityMenuProps) {
           <DefaultFontMenu />
         </DefaultMenuSection>
 
-        {slot(slots, 'accessibilitySettingsMenuItemsEnd', null)}
+        {slot(slots, 'accessibilityMenuItemsEnd', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/accessibility-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/accessibility-menu.tsx
@@ -24,7 +24,7 @@ function DefaultAccessibilityMenu({ slots }: DefaultAccessibilityMenuProps) {
     <Menu.Root className="vds-accessibility-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Accessibility} />
       <Menu.Content className="vds-menu-items">
-        {slot(slots, 'accessibilitySettingsMenuStartItems', null)}
+        {slot(slots, 'accessibilitySettingsMenuItemsStart', null)}
 
         <DefaultMenuSection>
           <DefaultAnnouncementsMenuCheckbox />
@@ -35,7 +35,7 @@ function DefaultAccessibilityMenu({ slots }: DefaultAccessibilityMenuProps) {
           <DefaultFontMenu />
         </DefaultMenuSection>
 
-        {slot(slots, 'accessibilitySettingsMenuEndItems', null)}
+        {slot(slots, 'accessibilitySettingsMenuItemsEnd', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/audio-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/audio-menu.tsx
@@ -7,6 +7,7 @@ import { useMediaState } from '../../../../../hooks/use-media-state';
 import * as Menu from '../../../../ui/menu';
 import * as AudioGainSlider from '../../../../ui/sliders/audio-gain-slider';
 import { useDefaultLayoutContext, useDefaultLayoutWord } from '../../context';
+import { slot, type DefaultLayoutMenuSlotName, type Slots } from '../../slots';
 import { DefaultMenuButton, DefaultMenuSection } from './items/menu-items';
 import { DefaultMenuSliderItem, DefaultSliderParts, DefaultSliderSteps } from './items/menu-slider';
 
@@ -14,7 +15,11 @@ import { DefaultMenuSliderItem, DefaultSliderParts, DefaultSliderSteps } from '.
  * DefaultAudioMenu
  * -----------------------------------------------------------------------------------------------*/
 
-function DefaultAudioMenu() {
+interface DefaultAudioMenuProps {
+  slots?: Slots<DefaultLayoutMenuSlotName>;
+}
+
+function DefaultAudioMenu({ slots }: DefaultAudioMenuProps) {
   const label = useDefaultLayoutWord('Audio'),
     $canSetAudioGain = useMediaState('canSetAudioGain'),
     $audioTracks = useMediaState('audioTracks'),
@@ -28,8 +33,10 @@ function DefaultAudioMenu() {
     <Menu.Root className="vds-audio-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Audio} />
       <Menu.Content className="vds-menu-items">
+        {slot(slots, 'audioSettingsMenuStartItems', null)}
         <DefaultAudioTracksMenu />
         {hasGainSlider ? <DefaultAudioBoostMenuSection /> : null}
+        {slot(slots, 'audioSettingsMenuEndItems', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/audio-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/audio-menu.tsx
@@ -33,10 +33,10 @@ function DefaultAudioMenu({ slots }: DefaultAudioMenuProps) {
     <Menu.Root className="vds-audio-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Audio} />
       <Menu.Content className="vds-menu-items">
-        {slot(slots, 'audioSettingsMenuItemsStart', null)}
+        {slot(slots, 'audioMenuItemsStart', null)}
         <DefaultAudioTracksMenu />
         {hasGainSlider ? <DefaultAudioBoostMenuSection /> : null}
-        {slot(slots, 'audioSettingsMenuItemsEnd', null)}
+        {slot(slots, 'audioMenuItemsEnd', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/audio-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/audio-menu.tsx
@@ -33,10 +33,10 @@ function DefaultAudioMenu({ slots }: DefaultAudioMenuProps) {
     <Menu.Root className="vds-audio-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Audio} />
       <Menu.Content className="vds-menu-items">
-        {slot(slots, 'audioSettingsMenuStartItems', null)}
+        {slot(slots, 'audioSettingsMenuItemsStart', null)}
         <DefaultAudioTracksMenu />
         {hasGainSlider ? <DefaultAudioBoostMenuSection /> : null}
-        {slot(slots, 'audioSettingsMenuEndItems', null)}
+        {slot(slots, 'audioSettingsMenuItemsEnd', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/captions-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/captions-menu.tsx
@@ -3,13 +3,18 @@ import * as React from 'react';
 import { useCaptionOptions } from '../../../../../hooks/options/use-caption-options';
 import * as Menu from '../../../../ui/menu';
 import { useDefaultLayoutContext, useDefaultLayoutWord } from '../../context';
+import { slot, type DefaultLayoutMenuSlotName, type Slots } from '../../slots';
 import { DefaultMenuButton } from './items/menu-items';
 
 /* -------------------------------------------------------------------------------------------------
  * DefaultCaptionMenu
  * -----------------------------------------------------------------------------------------------*/
 
-function DefaultCaptionMenu() {
+interface DefaultCaptionMenuProps {
+  slots?: Slots<DefaultLayoutMenuSlotName>;
+}
+
+function DefaultCaptionMenu({ slots }: DefaultCaptionMenuProps) {
   const { icons: Icons } = useDefaultLayoutContext(),
     label = useDefaultLayoutWord('Captions'),
     offText = useDefaultLayoutWord('Off'),
@@ -27,6 +32,8 @@ function DefaultCaptionMenu() {
         Icon={Icons.Menu.Captions}
       />
       <Menu.Content className="vds-menu-items">
+        {slot(slots, 'captionsMenuStartItems', null)}
+
         <Menu.RadioGroup
           className="vds-captions-radio-group vds-radio-group"
           value={options.selectedValue}
@@ -43,6 +50,8 @@ function DefaultCaptionMenu() {
             </Menu.Radio>
           ))}
         </Menu.RadioGroup>
+
+        {slot(slots, 'captionsMenuEndItems', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/captions-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/captions-menu.tsx
@@ -32,7 +32,7 @@ function DefaultCaptionMenu({ slots }: DefaultCaptionMenuProps) {
         Icon={Icons.Menu.Captions}
       />
       <Menu.Content className="vds-menu-items">
-        {slot(slots, 'captionsMenuStartItems', null)}
+        {slot(slots, 'captionsMenuItemsStart', null)}
 
         <Menu.RadioGroup
           className="vds-captions-radio-group vds-radio-group"
@@ -51,7 +51,7 @@ function DefaultCaptionMenu({ slots }: DefaultCaptionMenuProps) {
           ))}
         </Menu.RadioGroup>
 
-        {slot(slots, 'captionsMenuEndItems', null)}
+        {slot(slots, 'captionsMenuItemsEnd', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/playback-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/playback-menu.tsx
@@ -30,17 +30,17 @@ function DefaultPlaybackMenu({ slots }: DefaultPlaybackMenuProps) {
     <Menu.Root className="vds-accessibility-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Playback} />
       <Menu.Content className="vds-menu-items">
-        {slot(slots, 'playbackSettingsMenuItemsStart', null)}
+        {slot(slots, 'playbackMenuItemsStart', null)}
 
         <DefaultMenuSection>
-          {slot(slots, 'playbackSettingsMenuLoop', <DefaultLoopMenuCheckbox />)}
+          {slot(slots, 'playbackMenuLoop', <DefaultLoopMenuCheckbox />)}
         </DefaultMenuSection>
 
         <DefaultSpeedMenuSection />
 
         <DefaultQualityMenuSection />
 
-        {slot(slots, 'playbackSettingsMenuItemsEnd', null)}
+        {slot(slots, 'playbackMenuItemsEnd', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/playback-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/playback-menu.tsx
@@ -9,6 +9,7 @@ import * as Menu from '../../../../ui/menu';
 import * as QualitySlider from '../../../../ui/sliders/quality-slider';
 import * as SpeedSlider from '../../../../ui/sliders/speed-slider';
 import { useDefaultLayoutContext, useDefaultLayoutWord } from '../../context';
+import { slot, type DefaultLayoutMenuSlotName, type Slots } from '../../slots';
 import { DefaultMenuCheckbox } from './items/menu-checkbox';
 import { DefaultMenuButton, DefaultMenuItem, DefaultMenuSection } from './items/menu-items';
 import { DefaultMenuSliderItem, DefaultSliderParts, DefaultSliderSteps } from './items/menu-slider';
@@ -17,7 +18,11 @@ import { DefaultMenuSliderItem, DefaultSliderParts, DefaultSliderSteps } from '.
  * DefaultPlaybackMenu
  * -----------------------------------------------------------------------------------------------*/
 
-function DefaultPlaybackMenu() {
+interface DefaultPlaybackMenuProps {
+  slots?: Slots<DefaultLayoutMenuSlotName>;
+}
+
+function DefaultPlaybackMenu({ slots }: DefaultPlaybackMenuProps) {
   const label = useDefaultLayoutWord('Playback'),
     { icons: Icons } = useDefaultLayoutContext();
 
@@ -25,13 +30,17 @@ function DefaultPlaybackMenu() {
     <Menu.Root className="vds-accessibility-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Playback} />
       <Menu.Content className="vds-menu-items">
+        {slot(slots, 'playbackSettingsMenuStartItems', null)}
+
         <DefaultMenuSection>
-          <DefaultLoopMenuCheckbox />
+          {slot(slots, 'playbackSettingsMenuLoop', <DefaultLoopMenuCheckbox />)}
         </DefaultMenuSection>
 
         <DefaultSpeedMenuSection />
 
         <DefaultQualityMenuSection />
+
+        {slot(slots, 'playbackSettingsMenuEndItems', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/playback-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/playback-menu.tsx
@@ -30,7 +30,7 @@ function DefaultPlaybackMenu({ slots }: DefaultPlaybackMenuProps) {
     <Menu.Root className="vds-accessibility-menu vds-menu">
       <DefaultMenuButton label={label} Icon={Icons.Menu.Playback} />
       <Menu.Content className="vds-menu-items">
-        {slot(slots, 'playbackSettingsMenuStartItems', null)}
+        {slot(slots, 'playbackSettingsMenuItemsStart', null)}
 
         <DefaultMenuSection>
           {slot(slots, 'playbackSettingsMenuLoop', <DefaultLoopMenuCheckbox />)}
@@ -40,7 +40,7 @@ function DefaultPlaybackMenu({ slots }: DefaultPlaybackMenuProps) {
 
         <DefaultQualityMenuSection />
 
-        {slot(slots, 'playbackSettingsMenuEndItems', null)}
+        {slot(slots, 'playbackSettingsMenuItemsEnd', null)}
       </Menu.Content>
     </Menu.Root>
   );

--- a/packages/react/src/components/layouts/default/ui/menus/settings-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/settings-menu.tsx
@@ -60,10 +60,12 @@ function DefaultSettingsMenu({
       {isOpen ? (
         <>
           {slot(slots, 'settingsMenuItemsStart', null)}
+          {slot(slots, 'settingsMenuStartItems', null)}
           <DefaultPlaybackMenu slots={slots} />
           <DefaultAccessibilityMenu slots={slots} />
           <DefaultAudioMenu slots={slots} />
           <DefaultCaptionMenu slots={slots} />
+          {slot(slots, 'settingsMenuEndItems', null)}
           {slot(slots, 'settingsMenuItemsEnd', null)}
         </>
       ) : null}

--- a/packages/react/src/components/layouts/default/ui/menus/settings-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/settings-menu.tsx
@@ -60,10 +60,10 @@ function DefaultSettingsMenu({
       {isOpen ? (
         <>
           {slot(slots, 'settingsMenuStartItems', null)}
-          <DefaultPlaybackMenu />
-          <DefaultAccessibilityMenu />
-          <DefaultAudioMenu />
-          <DefaultCaptionMenu />
+          <DefaultPlaybackMenu slots={slots} />
+          <DefaultAccessibilityMenu slots={slots} />
+          <DefaultAudioMenu slots={slots} />
+          <DefaultCaptionMenu slots={slots} />
           {slot(slots, 'settingsMenuEndItems', null)}
         </>
       ) : null}

--- a/packages/react/src/components/layouts/default/ui/menus/settings-menu.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/settings-menu.tsx
@@ -59,12 +59,12 @@ function DefaultSettingsMenu({
     >
       {isOpen ? (
         <>
-          {slot(slots, 'settingsMenuStartItems', null)}
+          {slot(slots, 'settingsMenuItemsStart', null)}
           <DefaultPlaybackMenu slots={slots} />
           <DefaultAccessibilityMenu slots={slots} />
           <DefaultAudioMenu slots={slots} />
           <DefaultCaptionMenu slots={slots} />
-          {slot(slots, 'settingsMenuEndItems', null)}
+          {slot(slots, 'settingsMenuItemsEnd', null)}
         </>
       ) : null}
     </Menu.Content>


### PR DESCRIPTION
### Description:

Add slots for the various settings sub-menus, making it possible to add custom settings items to the new settings menu layout in v1.11.

New slots:

```
playbackSettingsMenuStartItems
playbackSettingsMenuEndItems
playbackSettingsMenuLoop
accessibilitySettingsMenuStartItems
accessibilitySettingsMenuEndItems
audioSettingsMenuStartItems
audioSettingsMenuEndItems
captionsMenuStartItems
captionsMenuEndItems
```

### Ready?

Yes.

### Example

```tsx
<DefaultVideoLayout
  icons={defaultLayoutIcons}
  slots={{
    beforePlaybackSettingsMenuLoop: (
      <DefaultMenuItem label="Autoplay">
        <DefaultMenuCheckbox label="Autoplay" />
      </DefaultMenuItem>
    ),
  }}
/>
```

![image](https://github.com/vidstack/player/assets/15160542/3dbc1382-d2c9-4703-bb49-8aaf2d9a258b)
