### PR TITLE
fix: Only instantiate `NavigatorMediaSession` in browsers with support for `MediaMetadata`.

### DIFF
--- a/packages/vidstack/src/components/player.ts
+++ b/packages/vidstack/src/components/player.ts
@@ -194,7 +194,10 @@ export class MediaPlayer
       context,
     );
 
-    new NavigatorMediaSession();
+    if ('mediaSession' in navigator) {
+      new NavigatorMediaSession();
+    }
+
     new MediaLoadController('load', this.startLoading.bind(this));
     new MediaLoadController('posterLoad', this.startLoadingPoster.bind(this));
   }


### PR DESCRIPTION
### Description:

The `MediaMetadata` API isn't supported universally, so this PR prevents uncaught exceptions by ensuring that the `NavigatorMediaSession` class (which has a dependency on `MediaMetadata`) is not instantiated on browsers without support.

The check is copied from the example on the [`MediaMetadata` MDN page](https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/metadata#example).

### Ready?

Yes
### Anything Else?

[caniuse.com: MediaMetadata (94.69% global support)](https://caniuse.com/mdn-api_mediametadata)

