### PR TITLE
fix(player): TypeError: format is not a function

### DIFF
--- a/packages/vidstack/src/components/ui/sliders/slider-value.ts
+++ b/packages/vidstack/src/components/ui/sliders/slider-value.ts
@@ -49,7 +49,7 @@ export class SliderValue extends Component<SliderValueProps> {
   getValueText() {
     const { type, format, decimalPlaces, padHours, padMinutes, showHours, showMs } = this.$props,
       { value: sliderValue, pointerValue, min, max } = this._slider,
-      _format = format() ?? this._format.default;
+      _format = (typeof format === 'function' ? format() : format) || this._format.default;
 
     const value = type() === 'current' ? sliderValue() : pointerValue();
 


### PR DESCRIPTION
### Related:

https://github.com/vidstack/player/assets/92907658/254b9ba6-4021-4ea4-95e7-85f05a351feb

### Description:
This error happen when switching continuously between landscape and portrait mode, the <Sliders.Time> component is repeatedly mounted and unmounted.

### Ready?

<!-- Is this PR ready to be reviewed? -->

### Review Process:

<!-- If possible, provide a checklist for what you'd expect us to do in order to review this PR. -->
