### PR TITLE
Fix: #1301 GUI not compatible with HTMLDialogElement API

### DIFF
--- a/packages/vidstack/src/elements/define/layouts/default/audio-layout-element.ts
+++ b/packages/vidstack/src/elements/define/layouts/default/audio-layout-element.ts
@@ -50,7 +50,7 @@ export class MediaAudioLayoutElement
     this._media = useMediaContext();
 
     this.classList.add('vds-audio-layout');
-    this.menuContainer = createMenuContainer('vds-audio-layout', () => this.isSmallLayout);
+    this.menuContainer = createMenuContainer(this, 'vds-audio-layout', () => this.isSmallLayout);
 
     const { pointer } = this._media.$state;
     effect(() => {

--- a/packages/vidstack/src/elements/define/layouts/default/ui/menu/menu-portal.ts
+++ b/packages/vidstack/src/elements/define/layouts/default/ui/menu/menu-portal.ts
@@ -21,7 +21,7 @@ export function createMenuContainer(layoutElement: Element, className: string, i
     container = document.createElement('div');
     container.style.display = 'contents';
     container.classList.add(className);
-    document.layoutElement.after(container);
+    layoutElement.after(container);
   }
 
   const { viewType } = useMediaState(),

--- a/packages/vidstack/src/elements/define/layouts/default/ui/menu/menu-portal.ts
+++ b/packages/vidstack/src/elements/define/layouts/default/ui/menu/menu-portal.ts
@@ -14,14 +14,14 @@ export function MenuPortal(container: HTMLElement | null, template: TemplateResu
   `;
 }
 
-export function createMenuContainer(className: string, isSmallLayout: ReadSignal<boolean>) {
+export function createMenuContainer(layoutElement: Element, className: string, isSmallLayout: ReadSignal<boolean>) {
   let container = document.querySelector<HTMLElement>(`body > .${className}`);
 
   if (!container) {
     container = document.createElement('div');
     container.style.display = 'contents';
     container.classList.add(className);
-    document.body.append(container);
+    document.layoutElement.after(container);
   }
 
   const { viewType } = useMediaState(),

--- a/packages/vidstack/src/elements/define/layouts/default/video-layout-element.ts
+++ b/packages/vidstack/src/elements/define/layouts/default/video-layout-element.ts
@@ -52,7 +52,7 @@ export class MediaVideoLayoutElement
     this._media = useMediaContext();
 
     this.classList.add('vds-video-layout');
-    this.menuContainer = createMenuContainer('vds-video-layout', () => this.isSmallLayout);
+    this.menuContainer = createMenuContainer(this, 'vds-video-layout', () => this.isSmallLayout);
 
     onDispose(() => this.menuContainer?.remove());
   }


### PR DESCRIPTION
### Related:

Fixes #1301.

### Description:
The GUI's settings pop-over (Quality, Playback speed, etc.) had no support for the [HTMLDialogElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement) API, making that part of the GUI unusable when rendering videos as `HTMLDialogElement`s.

This support was added by, instead of appending the settings pop-over (Quality, Playback speed, etc.) to the body, appending it to a given layoutElement (i.e. `this`), so that it now also natively supports rendering 'on top of' modals.

### Ready?

One issue remains (see more recent message).

### Anything Else?

[Schermopname van 2024-06-07 17-26-27.webm](https://github.com/vidstack/player/assets/101057635/2c9f3406-a2aa-4933-a5be-240e4abd0477)

