### PR TITLE
Fix: Aria-Announcer attemping to set the label on a null $state

### DIFF
--- a/packages/vidstack/src/components/aria/announcer.ts
+++ b/packages/vidstack/src/components/aria/announcer.ts
@@ -98,6 +98,9 @@ export class MediaAnnouncer extends Component<
     if (this._startedSeekingAt > 0) {
       window.clearTimeout(this._seekTimer);
       this._seekTimer = window.setTimeout(() => {
+        // Checking whether the component scope still exists (i.e., has it been destroyed?).
+        if (!this.scope) return;
+
         const newTime = peek(currentTime),
           seconds = Math.abs(newTime - this._startedSeekingAt);
 
@@ -105,12 +108,9 @@ export class MediaAnnouncer extends Component<
           const isForward = newTime >= this._startedSeekingAt,
             spokenTime = formatSpokenTime(seconds);
 
-          // We are inside a setTimeout, there is a chance the component has been unmounted and the state set to null.
-          if (this.$state) {
-            this._setLabel(
-              `${this._translate(isForward ? 'Seek Forward' : 'Seek Backward')} ${spokenTime}`,
-            );
-          }
+          this._setLabel(
+            `${this._translate(isForward ? 'Seek Forward' : 'Seek Backward')} ${spokenTime}`,
+          );
         }
 
         this._startedSeekingAt = -1;

--- a/packages/vidstack/src/components/aria/announcer.ts
+++ b/packages/vidstack/src/components/aria/announcer.ts
@@ -105,9 +105,12 @@ export class MediaAnnouncer extends Component<
           const isForward = newTime >= this._startedSeekingAt,
             spokenTime = formatSpokenTime(seconds);
 
-          this._setLabel(
-            `${this._translate(isForward ? 'Seek Forward' : 'Seek Backward')} ${spokenTime}`,
-          );
+          // We are inside a setTimeout, there is a chance the component has been unmounted and the state set to null.
+          if (this.$state) {
+            this._setLabel(
+              `${this._translate(isForward ? 'Seek Forward' : 'Seek Backward')} ${spokenTime}`,
+            );
+          }
         }
 
         this._startedSeekingAt = -1;


### PR DESCRIPTION
### Description:

This PR fixes a race condition affecting the aria-announcer component.

Currently, a `window.setTimeout` function is executed after 300ms to update the label to either "Seek Forward" or "Seek Backward." 

However when the component is unmounted, `$state` is set to null while the timeout is not cleared.

The callback then is executed on an invalid state, attempts to destructure `const { label } = this.$state` resulting in the exception `Cannot destructure property 'label' of 'this.$state' as it is null.`

https://github.com/vidstack/player/blob/08e31f00cd548285dce13bb617d573d676a5dc37/packages/vidstack/src/components/aria/announcer.ts#L99-L115

### Ready?

I hope so

### Anything Else?

The error appear to be benign and non critical, however it might cause all sort of nasty errors if left uncheck.

I have managed to catch this error in Sentry in a production build, it is really hard to replicate due to its timeout nature.

![image](https://github.com/vidstack/player/assets/100947658/bad7296f-6c8b-4f47-981d-81135a8c049e)

Vidstack version is `1.11.22`
Project runs on Nuxt with the Vite plugin
No apparent critical issue

### Review Process:

Hello there, as this is my first PR here, I would really like someone testing this code or carefully review it even tho I've only changed a single line.

Second, there should be a better way to handle this with a more appropriate solution that clears the `setTimeout` function.