### PR TITLE
Feat: improve unlisted Vimeo video url handling

### DIFF
--- a/packages/vidstack/src/providers/vimeo/loader.ts
+++ b/packages/vidstack/src/providers/vimeo/loader.ts
@@ -50,9 +50,9 @@ export class VimeoProviderLoader implements MediaProviderLoader<VimeoProvider> {
 
     if (!isString(src.src)) return null;
 
-    const { videoId } = resolveVimeoVideoId(src.src);
+    const { videoId, hash } = resolveVimeoVideoId(src.src);
     if (videoId) {
-      return getVimeoVideoInfo(videoId, abort).then((info) => (info ? info.poster : null));
+      return getVimeoVideoInfo(videoId, abort, hash).then((info) => (info ? info.poster : null));
     }
 
     return null;

--- a/packages/vidstack/src/providers/vimeo/provider.ts
+++ b/packages/vidstack/src/providers/vimeo/provider.ts
@@ -228,7 +228,7 @@ export class VimeoProvider
 
     this._videoInfoPromise = promise;
 
-    getVimeoVideoInfo(videoId, abort)
+    getVimeoVideoInfo(videoId, abort, this._hash)
       .then((info) => {
         promise.resolve(info);
       })

--- a/packages/vidstack/src/providers/vimeo/utils.ts
+++ b/packages/vidstack/src/providers/vimeo/utils.ts
@@ -1,6 +1,7 @@
 import type { VimeoOEmbedData, VimeoVideoInfo } from './embed/misc';
 
-const videoIdRE = /(?:https:\/\/)?(?:player\.)?vimeo(?:\.com)?\/(?:video\/)?(\d+)(?:\?hash=(.*))?/;
+const videoIdRE =
+  /(?:https:\/\/)?(?:player\.)?vimeo(?:\.com)?\/(?:video\/)?(\d+)(?:(?:\?hash=|\?h=|\/)(.*))?/;
 
 const infoCache = new Map<string, VimeoVideoInfo>();
 
@@ -11,12 +12,19 @@ export function resolveVimeoVideoId(src: string) {
   return { videoId: matches?.[1], hash: matches?.[2] };
 }
 
-export async function getVimeoVideoInfo(videoId: string, abort: AbortController) {
+export async function getVimeoVideoInfo(
+  videoId: string,
+  abort: AbortController,
+  videoHash?: string | null,
+) {
   if (infoCache.has(videoId)) return infoCache.get(videoId)!;
 
   if (pendingFetch.has(videoId)) return pendingFetch.get(videoId);
 
-  const oembedSrc = `https://vimeo.com/api/oembed.json?url=https://player.vimeo.com/video/${videoId}`;
+  let oembedSrc = `https://vimeo.com/api/oembed.json?url=https://player.vimeo.com/video/${videoId}`;
+  if (videoHash) {
+    oembedSrc = oembedSrc.concat(`?h=${videoHash}`);
+  }
 
   const promise = window
     .fetch(oembedSrc, {


### PR DESCRIPTION
### Related:
https://github.com/vidstack/player/issues/1100

### Description:
Currently, there are still some issues regarding unlisted Vimeo videos:
- Only videos with URL's using the `hash` path parameter are loaded.
- The `getVimeoVideoInfo` fails when retrieving the video info because the hash isn't provided.

 This pr updates the Vimeo provider regex to retrieve to support the hash parameter as `h` (which is used in the embedded URL) or with `video-id>/<video-hash>`.
 - `https://vimeo.com/video/<video-id>?h=<video-hash>`
 - `https://player.vimeo.com/video/<video-id>/<video-hash>`


### Ready?
Yes.