### PR TITLE
Set poster image fallback src to undefined, not empty string

### DIFF
--- a/packages/react/src/components/ui/poster.tsx
+++ b/packages/react/src/components/ui/poster.tsx
@@ -79,7 +79,7 @@ const PosterImg = React.forwardRef<HTMLImageElement, PosterImgProps>(
     return (
       <Primitive.img
         {...props}
-        src={$src || ''}
+        src={$src || undefined}
         alt={$alt || undefined}
         crossOrigin={$crossOrigin || undefined}
         ref={composeRefs(img.set as React.Ref<HTMLImageElement>, forwardRef)}


### PR DESCRIPTION
When loading a Poster image using the React API, I noticed react-dom (`19.0.0-beta-26f2496093-20240514`) presented this warning:

> Warning: An empty string ("") was passed to the src attribute. This may cause the browser to download the whole page again over the network. To fix this, either do not render the element at all or pass null to src instead of an empty string.

I found [a writeup of the empty string `src` problem](https://humanwhocodes.com/blog/2009/11/30/empty-image-src-can-destroy-your-site/) from back in 2009(!). So I guess that kind of problem is what the warning is about.

This warning was triggered even if the Vidstack poster component was only ever rendered with a string, so seemed to me unworkaroundable.

I traced this back to this line in the Poster component, which at some point in rendering would fall back to setting `src` to an empty string.

It appears undefined is always preferable to an empty string here, so this change would appear to be low risk.

Note that I have picked `undefined` instead of `null` as the warning advises, since `null` appears not to typecheck. This also aligns with the approach in the `SliderVideoProvider` component (which also falls back to `undefined` for `src` on its `video` tag)

Thanks again for all of your work on vidstack and I hope this PR is useful.