### PR TITLE
Bug fix; seeking backwards on remote control went forwards in some cases

### DIFF
--- a/packages/vidstack/src/core/state/navigator-media-session.ts
+++ b/packages/vidstack/src/core/state/navigator-media-session.ts
@@ -53,7 +53,7 @@ export class NavigatorMediaSession extends MediaPlayerController {
         this.dispatch('media-seek-request', {
           detail: isNumber(details.seekTime)
             ? details.seekTime
-            : this.$state.currentTime() + (details.seekOffset ?? 10),
+            : this.$state.currentTime() + (details.seekOffset ?? (details.action === "seekforward" ? 10 : -10)),
           trigger,
         });
         break;


### PR DESCRIPTION
**Bug fix** -- When you click the "seek backward" button using a remote control (such as on a smart TV's web browser), it jumps forward instead of backward.  This behavior can be replicated in Chrome using its built-in Media Control feature.

### Steps to replicate

- Open Google Chrome.
- Go to the [demos page](https://www.vidstack.io/player/demo) (or open any Vidstack player on version 1.12.1-next).
- Play the video.
- Click the Media Control button in Chrome, as shown here:
![image](https://github.com/user-attachments/assets/bb3d17ac-6aaf-4d13-a776-32660a5e525a)
- Click the rewind / "seek backward" button in Chrome's Media Control pop-up, as shown here:
![image](https://github.com/user-attachments/assets/222db16b-af74-48f8-a1f7-dc53363485c6)


You should see that time has jumped **forward** by 10 seconds.

The expected behavior is that it should jump **backward** by 10 seconds.


