### PR TITLE
fix(player): add audio/mp4 mime type

### DIFF
--- a/packages/vidstack/src/utils/mime.ts
+++ b/packages/vidstack/src/utils/mime.ts
@@ -18,6 +18,7 @@ export const AUDIO_TYPES = new Set<string>([
   'audio/m4a',
   'audio/m4b',
   'audio/mp4a',
+  'audio/mp4',
 ]);
 
 // https://github.com/cookpete/react-player/blob/master/src/patterns.js#L16


### PR DESCRIPTION
### Related:

https://github.com/vidstack/player/commit/6801a8402e2bc3f98e9763b920ed1355de48f72b

### Description:

This fixes the playback of *.m4a files uploaded through Rails/ActiveStorage, as their content type is defined (through the [Marcel](https://github.com/rails/marcel) gem) as `audio/mp4`.

### Ready?

Yes

### Anything Else?

See discussion - https://discord.com/channels/742612686679965696/1107494438684606554/threads/1271131720061550664

### Review Process:

<!-- If possible, provide a checklist for what you'd expect us to do in order to review this PR. -->
