### PR TITLE
Remove early usage of chrome API

### DIFF
--- a/packages/vidstack/src/providers/google-cast/tracks.ts
+++ b/packages/vidstack/src/providers/google-cast/tracks.ts
@@ -7,9 +7,6 @@ import type { TextTrack, TextTrackInit } from '../../core/tracks/text/text-track
 import { ListSymbol } from '../../foundation/list/symbols';
 import { getCastSessionMedia } from './utils';
 
-const REMOTE_TRACK_TEXT_TYPE = chrome.cast.media.TrackType.TEXT,
-  REMOTE_TRACK_AUDIO_TYPE = chrome.cast.media.TrackType.AUDIO;
-
 export class GoogleCastTracksManager {
   #cast: cast.framework.RemotePlayer;
   #ctx: MediaContext;
@@ -48,13 +45,13 @@ export class GoogleCastTracksManager {
       activeLocalTextTracks = this.getLocalTextTracks().filter((track) => track.mode === 'showing');
 
     if (activeLocalAudioTrack) {
-      const remoteAudioTracks = this.#getRemoteTracks(REMOTE_TRACK_AUDIO_TYPE),
+      const remoteAudioTracks = this.#getRemoteTracks(chrome.cast.media.TrackType.AUDIO),
         remoteAudioTrack = this.#findRemoteTrack(remoteAudioTracks, activeLocalAudioTrack);
       if (remoteAudioTrack) activeIds.push(remoteAudioTrack.trackId);
     }
 
     if (activeLocalTextTracks?.length) {
-      const remoteTextTracks = this.#getRemoteTracks(REMOTE_TRACK_TEXT_TYPE);
+      const remoteTextTracks = this.#getRemoteTracks(chrome.cast.media.TrackType.TEXT);
       if (remoteTextTracks.length) {
         for (const localTrack of activeLocalTextTracks) {
           const remoteTextTrack = this.#findRemoteTrack(remoteTextTracks, localTrack);
@@ -71,7 +68,7 @@ export class GoogleCastTracksManager {
 
     if (!this.#cast.isMediaLoaded) return;
 
-    const remoteTextTracks = this.#getRemoteTracks(REMOTE_TRACK_TEXT_TYPE);
+    const remoteTextTracks = this.#getRemoteTracks(chrome.cast.media.TrackType.TEXT);
 
     // Sync local tracks with remote cast player.
     for (const localTrack of localTextTracks) {
@@ -89,8 +86,8 @@ export class GoogleCastTracksManager {
 
     const localAudioTracks = this.#getLocalAudioTracks(),
       localTextTracks = this.getLocalTextTracks(),
-      remoteAudioTracks = this.#getRemoteTracks(REMOTE_TRACK_AUDIO_TYPE),
-      remoteTextTracks = this.#getRemoteTracks(REMOTE_TRACK_TEXT_TYPE);
+      remoteAudioTracks = this.#getRemoteTracks(chrome.cast.media.TrackType.AUDIO),
+      remoteTextTracks = this.#getRemoteTracks(chrome.cast.media.TrackType.TEXT);
 
     // Sync remote audio tracks with local player.
     for (const remoteAudioTrack of remoteAudioTracks) {


### PR DESCRIPTION
### Related:

N/A

### Description:

When running Vidstack in a Capacitor app, the app fails to start because of a ReferenceError:
`ReferenceError: chrome is not defined`
This happens because _tracks.ts_ directly references the `chrome` API on import.
This typically doesn't happen when the app is bundled into neatly split dependencies as Vite does by default, but when generating a single bundle that contains the entire app, the `chrome` API will be accessed immediately regardless of the browser used.

This PR prevents the `chrome` API from being referenced early.

### Ready?

Yes

### Anything Else?

No

### Review Process:

<!-- If possible, provide a checklist for what you'd expect us to do in order to review this PR. -->
