### PR TITLE
fix: wrong youtube iframe height

### DIFF
--- a/packages/vidstack/styles/player/base.css
+++ b/packages/vidstack/styles/player/base.css
@@ -101,7 +101,7 @@
 }
 
 iframe.vds-youtube[data-no-controls] {
-  height: 1000%;
+  height: 100%;
 }
 
 .vds-blocker {


### PR DESCRIPTION
### Related:

/

### Description:

The iframe height was set to `1000%` instead of `100%` wich resulted in a cropped and pixelated preview image.

### Ready?

yes

### Anything Else?

/

### Review Process:

/
