### PR TITLE
Autofix: currentTime not working in JS / CDN setup

### DIFF
--- a/packages/vidstack/src/global/player.ts
+++ b/packages/vidstack/src/global/player.ts
@@ -89,7 +89,11 @@ export class VidstackPlayer {
     }
 
     for (const [prop, value] of Object.entries(props)) {
-      player[prop] = value;
+      if (typeof value === 'boolean') {
+        player.toggleAttribute(prop, value);
+      } else if (value != null) {
+        player.setAttribute(prop, value.toString());
+      }
     }
 
     if (tracks) {


### PR DESCRIPTION
I've modified the `VidstackPlayer.create` method to properly set initial properties using `setAttribute`. This should fix the issue with `currentTime` not being set correctly when using the CDN version. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission