### PR TITLE
Respect user preference for reduced motion when autoplaying

### DIFF
--- a/packages/vidstack/src/core/state/media-player-delegate.ts
+++ b/packages/vidstack/src/core/state/media-player-delegate.ts
@@ -156,7 +156,7 @@ export class MediaPlayerDelegate {
           ?.errorGroup('[vidstack] auto-play request failed')
           .labelledLog(
             'Message',
-            `Autoplay was requested but failed most likely due to browser autoplay policies.${muteMsg}`,
+            `Autoplay was requested but failed most likely due to browser autoplay policies or accessibility reasons.${muteMsg}`,
           )
           .labelledLog('Trigger Event', trigger)
           .labelledLog('Error', error)

--- a/packages/vidstack/src/core/state/media-request-manager.ts
+++ b/packages/vidstack/src/core/state/media-request-manager.ts
@@ -22,6 +22,7 @@ import { MediaPlayerController } from '../api/player-controller';
 import { boundTime } from '../api/player-state';
 import { MediaControls } from '../controls';
 import type { MediaStateManager } from './media-state-manager';
+import { prefersReducedMotion } from '../../utils/aria';
 
 /**
  * This class is responsible for listening to media request events and calling the appropriate
@@ -155,6 +156,7 @@ export class MediaRequestManager extends MediaPlayerController implements MediaR
     try {
       const provider = peek(this.#$provider);
       throwIfNotReadyForPlayback(provider, peek(canPlay));
+      throwIfAutoplayingWithReducedMotion(isAutoPlaying);
       return await provider!.play();
     } catch (error) {
       if (__DEV__) this.#logError('play request failed', error, trigger);
@@ -884,6 +886,15 @@ function throwIfFullscreenNotSupported(
     __DEV__
       ? `[vidstack] fullscreen is not currently available on target \`${target}\``
       : '[vidstack] no fullscreen support',
+  );
+}
+
+function throwIfAutoplayingWithReducedMotion(autoplaying: boolean) {
+  if (!prefersReducedMotion() || !autoplaying) return;
+  throw Error(
+    __DEV__
+      ? '[vidstack] autoplay is blocked due to user preference for reduced motion'
+      : '[vidstack] autoplay blocked',
   );
 }
 

--- a/packages/vidstack/src/utils/aria.ts
+++ b/packages/vidstack/src/utils/aria.ts
@@ -7,3 +7,8 @@ export function ariaBool(value: boolean): 'true' | 'false' {
 export function $ariaBool(signal: ReadSignal<boolean>): ReadSignal<'true' | 'false'> {
   return () => ariaBool(signal());
 }
+
+export function prefersReducedMotion() {
+  if (typeof window === 'undefined') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}


### PR DESCRIPTION
### Related:

closes #1479

### Description:

I already opened an issue and now had time to dig into the code.
When a user has reduced motion settings enabled in their system preferences, the player should respect this setting and not autoplay videos, regardless of the autoplay attribute value. This aligns with accessibility best practices and user preferences for reduced motion.

As a dev we could handle this with a simple check as @ianmiller347 already mentioned in the issue for example. But i think it would be a good practice to implement this directly so it works out of the box.

If the user prefers reduced motion and its autoplaying we throw during the `play` and not `attemptAutoplay` method because the `auto-play-failed` event is triggered by the `play-fail` event. Maybe i overlooked something and this could be improved.

### Ready?

Yes

### Anything Else?

No

### Review Process: