### PR TITLE
Fix: Resolve AirPlay Availability Issues by Enabling Remote Playback

### DIFF
--- a/packages/vidstack/src/providers/hls/hls.ts
+++ b/packages/vidstack/src/providers/hls/hls.ts
@@ -56,6 +56,10 @@ export class HLSController {
     });
 
     this.#instance.attachMedia(this.#video);
+
+    // Enable remote playback for AirPlay 
+    this.#video.disableRemotePlayback = false;
+
     this.#instance.on(ctor.Events.AUDIO_TRACK_SWITCHED, this.#onAudioSwitch.bind(this));
     this.#instance.on(ctor.Events.LEVEL_SWITCHED, this.#onLevelSwitched.bind(this));
     this.#instance.on(ctor.Events.LEVEL_LOADED, this.#onLevelLoaded.bind(this));


### PR DESCRIPTION
### Related:

closes https://github.com/vidstack/player/issues/1522

### Description:

In the Hls.js repository, there are [lines of code](https://github.com/video-dev/hls.js/blob/85c3cecd213ac8a0e26db52ee80ca36bfb2fcd4c/src/controller/buffer-controller.ts#L298) that remove video sources and set `disableRemotePlayback` to `true`.

In your `vidstack/player` code, I found only [appending sources](https://github.com/vidstack/player/blob/ac1fe3d7841d136127c4cd1663ace36262f32c4d/packages/vidstack/src/providers/html/provider.ts#L108C3-L110C6) after attaching an element to the Hls.js instance. However, there's no code to set `disableRemotePlayback` to `false` after this attachment.

**Impact:**
Not setting `disableRemotePlayback` to `false` disrupts the logic when [watching the availability of AirPlay state](https://github.com/vidstack/player/blob/ac1fe3d7841d136127c4cd1663ace36262f32c4d/packages/vidstack/src/providers/html/remote-playback.ts#L31-L37). When `disableRemotePlayback` is `true`, `watchAvailability` throws an error indicating an invalid state, and the support flag remains `false`. Consequently, the AirPlay button does not appear.

**Additional Note:**
There's another issue with AirPlay functionality: to work correctly on iOS with Hls.js, the video element must have `autoplay` set to `true`. Without it, AirPlay doesn't function as expected. This might be an issue with iOS itself.

```javascript
this.#video.disableRemotePlayback = false;
this.#video.autoplay = true;
```

### Ready?

The provided code resolves the issue by allowing the remote playback API to accurately detect AirPlay availability. However, I recommend integrating this fix in a more appropriate location within the codebase to maintain code quality and consistency. Additionally, addressing the autoplay requirement for iOS should be considered, potentially as a separate issue.

### Anything Else?

https://github.com/video-dev/hls.js/issues/6482

