### PR TITLE
Youtube shorts

### DIFF
--- a/packages/vidstack/src/providers/youtube/provider.ts
+++ b/packages/vidstack/src/providers/youtube/provider.ts
@@ -183,6 +183,7 @@ export class YouTubeProvider
       { muted, playsInline, nativeControls } = this.#ctx.$state,
       showControls = nativeControls();
     return {
+      rel: 0,
       autoplay: 0,
       cc_lang_pref: this.language,
       cc_load_policy: showControls ? 1 : undefined,

--- a/packages/vidstack/src/providers/youtube/utils.ts
+++ b/packages/vidstack/src/providers/youtube/utils.ts
@@ -1,5 +1,5 @@
 const videoIdRE =
-  /(?:youtu\.be|youtube|youtube\.com|youtube-nocookie\.com)\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|)((?:\w|-){11})/;
+  /(?:youtu\.be|youtube|youtube\.com|youtube-nocookie\.com)(?:\/shorts)?\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=|)((?:\w|-){11})/;
 
 const posterCache = new Map<string, string>();
 


### PR DESCRIPTION
### Related:

#1510 #1058 #1571

### Description:

- It modifies the youtube regex to handle shorts urls by adding an optional, non-matching group.
- It defaults to rel=0 in the video url parameters to hide related videos as a default.

### Ready?

Yes

### Anything Else?

These are small changes and shouldn't have many (if any) side effects.

### Review Process:

- Feed examples of each youtube url (including shorts) into the MediaPlayer component.
- Look for related videos at the end of a youtube video.