### PR TITLE
feat(react player): allow react ^19.0.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,8 +27,8 @@
     "watch:types": "pnpm run declarations -w & pnpm run build:types -w"
   },
   "peerDependencies": {
-    "@types/react": "^18.0.0",
-    "react": "^18.0.0"
+    "@types/react": "^18.0.0 || ^19.0.0",
+    "react": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.6.10",
@@ -38,8 +38,8 @@
     "@maverick-js/cli": "0.43.2",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@types/fs-extra": "^11.0.4",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.1",
     "esbuild": "^0.23.0",
     "fs-extra": "^11.2.0",
@@ -47,8 +47,8 @@
     "magic-string": "^0.30.11",
     "maverick.js": "0.43.2",
     "media-icons": "^1.1.5",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "remotion": "^4.0.193",
     "rimraf": "^3.0.2",
     "rollup": "^4.20.0",


### PR DESCRIPTION
### Related:
Issue: https://github.com/vidstack/player/issues/1533

### Description:
React 19 stable has been released some weeks ago, but @vidstack/react is not yet compatible with it yet.
This also makes it impossible to use it inside NextJS 15 projects.

### Ready?
Dependencies have been upgraded, everything kept working as expected.

### Review Process:
Check all functions in the react sandbox example with react 19 and 18.
