### PR TITLE
Added timeDivider type to default slots.tsx

### DIFF
--- a/packages/react/src/components/layouts/default/slots.tsx
+++ b/packages/react/src/components/layouts/default/slots.tsx
@@ -20,6 +20,7 @@ export type DefaultLayoutSlotName =
   | 'title'
   | 'chapterTitle'
   | 'currentTime'
+  | 'timeSeparator'
   | 'endTime'
   | 'fullscreenButton'
   | 'liveButton'

--- a/packages/react/src/components/layouts/default/slots.tsx
+++ b/packages/react/src/components/layouts/default/slots.tsx
@@ -20,7 +20,7 @@ export type DefaultLayoutSlotName =
   | 'title'
   | 'chapterTitle'
   | 'currentTime'
-  | 'timeSeparator'
+  | 'timeDivider'
   | 'endTime'
   | 'fullscreenButton'
   | 'liveButton'

--- a/packages/react/src/components/layouts/default/ui/time.tsx
+++ b/packages/react/src/components/layouts/default/ui/time.tsx
@@ -23,7 +23,7 @@ function DefaultTimeGroup({ slots }: { slots?: DefaultTimeGroupSlots }) {
   return (
     <div className="vds-time-group">
       {slot(slots, 'currentTime', <Time className="vds-time" type="current" />)}
-      {slot(slots, 'timeSeparator', <div className="vds-time-divider">/</div>)}
+      {slot(slots, 'timeDivider', <div className="vds-time-divider">/</div>)}
       {slot(slots, 'endTime', <Time className="vds-time" type="duration" />)}
     </div>
   );


### PR DESCRIPTION
### Description  

I added a missing slot value, `timeDivider `, in the **Default Component**. This slot is already used in the **Time Component**, but it was missing from the **Default Component**, leading to inconsistency in the layout.  

Reference to the relevant code:  
[[Time Component - Line 26](https://github.com/vidstack/player/blob/36cdc06ebb347c786088821ba21ffb96c1334fe5/packages/react/src/components/layouts/default/ui/time.tsx#L26)](https://github.com/vidstack/player/blob/36cdc06ebb347c786088821ba21ffb96c1334fe5/packages/react/src/components/layouts/default/ui/time.tsx#L26)  

### Example Usage  

```jsx
<DefaultVideoLayout 
  icons={defaultLayoutIcons} 
  slots={{ timeDivider: ' - ' }} 
/>
```

### Ready?  

Yes  
