### PR TITLE
Apply guard to quality radio group element to prevent it rendering twice

### DIFF
--- a/packages/vidstack/src/elements/define/menus/quality-radio-group-element.ts
+++ b/packages/vidstack/src/elements/define/menus/quality-radio-group-element.ts
@@ -31,7 +31,14 @@ import { renderMenuItemsTemplate } from './_template';
 export class MediaQualityRadioGroupElement extends Host(HTMLElement, QualityRadioGroup) {
   static tagName = 'media-quality-radio-group';
 
+  #connectedRanOnce: Boolean = false;
+
   protected onConnect(): void {
+    // onConnect can run more than once (eg, Phoenix LiveView after navigation)
+    if (this.#connectedRanOnce) return;
+
+    this.#connectedRanOnce = true;
+
     renderMenuItemsTemplate(this, (el, option) => {
       const bitrate = (option as QualityRadioOption).bitrate,
         bitrateEl = el.querySelector('[data-part="bitrate"]');


### PR DESCRIPTION
### Related:

#1586 #1617

### Description:

This PR prevents the speed radio group from rendering twice. See screenshot below.

### Ready?

Yes.

### Anything Else?

![image](https://github.com/user-attachments/assets/e6f4b2d9-2a74-4a39-8b28-d4a660e7490e)

### Review Process:


