### PR TITLE
Apply guard to speed radio group element to prevent it rendering twice

### DIFF
--- a/packages/vidstack/src/elements/define/menus/speed-radio-group-element.ts
+++ b/packages/vidstack/src/elements/define/menus/speed-radio-group-element.ts
@@ -25,7 +25,14 @@ import { renderMenuItemsTemplate } from './_template';
 export class MediaSpeedRadioGroupElement extends Host(HTMLElement, SpeedRadioGroup) {
   static tagName = 'media-speed-radio-group';
 
+  #connectedRanOnce: Boolean = false;
+
   protected onConnect(): void {
+    // onConnect can run more than once (eg, Phoenix LiveView after navigation)
+    if (this.#connectedRanOnce) return;
+
+    this.#connectedRanOnce = true;
+
     renderMenuItemsTemplate(this);
   }
 }


### PR DESCRIPTION
### Related:

#1586 #1616

### Description:

This PR prevents the quality radio group from rendering twice. See screenshot below.

### Ready?

Yes.

### Anything Else?

![image](https://github.com/user-attachments/assets/44fc58d0-d341-4f6e-8607-f3ee3e91f6b3)

### Review Process:


