### PR TITLE
Fix Vimeo loop support

### DIFF
--- a/packages/vidstack/src/providers/vimeo/provider.ts
+++ b/packages/vidstack/src/providers/vimeo/provider.ts
@@ -273,9 +273,10 @@ export class VimeoProvider
 
   protected override buildParams(): VimeoParams {
     const { keyDisabled } = this.#ctx.$props,
-      { playsInline, nativeControls } = this.#ctx.$state,
+      { playsInline, nativeControls, loop } = this.#ctx.$state,
       showControls = nativeControls();
-    return {
+
+    const params: VimeoParams = {
       title: this.title,
       byline: this.byline,
       color: this.color,
@@ -287,6 +288,14 @@ export class VimeoProvider
       playsinline: playsInline(),
       dnt: !this.cookies,
     };
+
+    // Add loop support for Vimeo
+    if (loop()) {
+      params.loop = true;
+      params.autopause = false;
+    }
+
+    return params;
   }
 
   #onAnimationFrame() {


### PR DESCRIPTION
### Related:
https://github.com/vidstack/player/issues/1542

### Description:
Add loop support for Vimeo by modifying buildParams() method to include loop and autopause parameters when loop state is enabled. The Vimeo provider was not converting the HTML5 loop attribute to the required Vimeo iframe URL parameters.

### Ready?
Yes

### Anything Else?
-  No breaking changes

### Review Process:
1. Test with Vimeo video and loop enabled, muted
2. Verify loop parameters are added to iframe URL
3. Pause and resume the the video randomly. 
3. Confirm video restarts after completion
4. Check that YouTube and HTML5 providers still work correctly
