### PR TITLE
fix #1582: Missing Poster attribute on Video Element

### DIFF
--- a/packages/react/src/components/provider.tsx
+++ b/packages/react/src/components/provider.tsx
@@ -168,7 +168,7 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
           ...mediaProps,
           controls: $nativeControls ? true : null,
           crossOrigin: typeof $crossOrigin === 'boolean' ? '' : $crossOrigin,
-          poster: $mediaType === 'video' && $nativeControls && $poster ? $poster : null,
+          poster: $mediaType === 'video' && $poster ? $poster : null,
           suppressHydrationWarning: true,
           children: !hasMounted
             ? $sources.map(({ src, type }) =>

--- a/packages/vidstack/src/elements/define/provider-element.ts
+++ b/packages/vidstack/src/elements/define/provider-element.ts
@@ -113,13 +113,12 @@ export class MediaProviderElement extends Host(HTMLElement, MediaProvider) {
       this.#target instanceof HTMLVideoElement ? this.#target : document.createElement('video');
 
     const { crossOrigin, poster, nativeControls } = this.#media.$state,
-      $controls = computed(() => (nativeControls() ? 'true' : null)),
-      $poster = computed(() => (poster() && nativeControls() ? poster() : null));
+      $controls = computed(() => (nativeControls() ? 'true' : null));
 
     effect(() => {
       setAttribute(video, 'controls', $controls());
       setAttribute(video, 'crossorigin', crossOrigin());
-      setAttribute(video, 'poster', $poster());
+      setAttribute(video, 'poster', poster());
     });
 
     return video;


### PR DESCRIPTION

### Description:

Fix poster attribute only being set when nativeControls is enabled.
The poster was incorrectly conditional on nativeControls in both the
core provider element and React provider, causing poster images to
not display when using custom video controls.

### Changes:
  - Remove `nativeControls` condition from poster attribute in `provider-element.ts`
  - Remove `nativeControls` condition from poster attribute in React `provider.tsx`

  Fixes poster display for video players using custom controls instead
  of native browser controls.

###  Summary of Changes Made:

#### Fixed Files:

  1. `/packages/vidstack/src/elements/define/provider-element.ts` - Line 121 (but this wasn't the actual issue for React apps)
  2. `/packages/react/src/components/provider.tsx` - Line 171 (this was the real fix for react)

### Ready?

Tried it with buck bunny and seems to work.
