### PR TITLE
Dedup segmented webvtt captions with the same id (fixes #1688)

### DIFF
--- a/packages/vidstack/src/core/tracks/text/text-track.ts
+++ b/packages/vidstack/src/core/tracks/text/text-track.ts
@@ -159,6 +159,7 @@ export class TextTrack extends EventsTarget<TextTrackEvents> {
     const index = this.#cues.indexOf(cue);
     if (index >= 0) {
       const isActive = this.#activeCues.includes(cue);
+      if (cue.id) this.#cueIds.delete(cue.id);
       this.#cues.splice(index, 1);
       this[TextTrackSymbol.native]?.track.removeCue(cue);
       this.dispatchEvent(new DOMEvent<VTTCue>('remove-cue', { detail: cue, trigger }));

--- a/packages/vidstack/src/core/tracks/text/text-track.ts
+++ b/packages/vidstack/src/core/tracks/text/text-track.ts
@@ -54,6 +54,7 @@ export class TextTrack extends EventsTarget<TextTrackEvents> {
   #regions: VTTRegion[] = [];
   #cues: VTTCue[] = [];
   #activeCues: VTTCue[] = [];
+  #cueIds = new Set<string>();
 
   /** @internal */
   [TextTrackSymbol.readyState]: TextTrackReadyState = 0;
@@ -128,6 +129,12 @@ export class TextTrack extends EventsTarget<TextTrackEvents> {
   }
 
   addCue(cue: VTTCue, trigger?: Event): void {
+    // deduplicate cues with the same id
+    if (cue.id) {
+      if (this.#cueIds.has(cue.id)) return;
+      this.#cueIds.add(cue.id);
+    }
+
     let i = 0,
       length = this.#cues.length;
 


### PR DESCRIPTION
### Related:

Issue: #1688 

### Description:

`addCue` now checks if the cue's identifier has already been processed. Duplicate cues (by identifier) are ignored.

**Why duplicates occur:**

Segmented WebVTT files can split a cue across segment boundaries. In such cases, the same cue may appear in multiple segments. Deduplicating by `id` prevents the same cue from appearing twice on screen, without affecting cues that legitimately share content but have different IDs.

Example — Segmented WebVTT:

_Segment 1:_

```
WEBVTT
X-TIMESTAMP-MAP=MPEGTS:456512,LOCAL:00:00:00.000

1
00:00:11.000 --> 00:00:13.000
<v Roger Bingham>We are in New York City
```

_Segment 2_

```
WEBVTT
X-TIMESTAMP-MAP=MPEGTS:456512,LOCAL:00:00:00.000

1
00:00:11.000 --> 00:00:13.000
<v Roger Bingham>We are in New York City

2
00:00:13.001 --> 00:00:16.000
<v Roger Bingham>We're actually at the Lucern Hotel, just down the street

3
00:00:16.000 --> 00:00:18.000
<v Roger Bingham>from the American Museum of Natural History

4
00:00:18.000 --> 00:00:20.000
<v Roger Bingham>And with me is Neil deGrasse Tyson
```

This would follow the approach used by `hls.js` to deduplicate cues across segments
See: https://github.com/video-dev/hls.js/issues/4563

### Ready?

Ready to be reviewed

### Anything Else?


**Before**
<img width="730" height="422" alt="image" src="https://github.com/user-attachments/assets/c4e12227-38bc-43ee-9952-8f2418786321" />


**After**
<img width="783" height="456" alt="Screenshot 2025-09-04 at 12 00 25 PM" src="https://github.com/user-attachments/assets/216b236c-fc5b-4ff4-98eb-9b956d71df42" />

