### PR TITLE
fix: export missing GoogleCastOptions type

### DIFF
--- a/packages/vidstack/src/exports/providers.ts
+++ b/packages/vidstack/src/exports/providers.ts
@@ -32,6 +32,7 @@ export type { DASHProvider } from '../providers/dash/provider';
 export type { GoogleCastLoader } from '../providers/google-cast/loader';
 export type { GoogleCastProvider } from '../providers/google-cast/provider';
 export type * from '../providers/google-cast/events';
+export type * from '../providers/google-cast/types';
 
 // Vimeo
 export { VimeoProviderLoader } from '../providers/vimeo/loader';


### PR DESCRIPTION
## Summary

- Export `GoogleCastOptions` type from `providers` barrel file, fixing TS4023 when using `vidstack/vue` with `composite: true`

Fixes #1757

## Test plan

- [ ] Create a Vue + TypeScript project with `composite: true` and `vueCompilerOptions` in tsconfig
- [ ] Import `vidstack/vue` types and use `<media-player>` component
- [ ] Run `npx vue-tsc --noEmit` and confirm no TS4023 error