### PR TITLE
fix: export missing Vue component prop types

### DIFF
--- a/packages/vidstack/src/elements/define/chapter-title-element.ts
+++ b/packages/vidstack/src/elements/define/chapter-title-element.ts
@@ -4,7 +4,7 @@ import { Host } from 'maverick.js/element';
 import { useMediaContext, type MediaContext } from '../../core/api/media-context';
 import { watchCueTextChange } from '../../core/tracks/text/utils';
 
-interface ChapterTitleProps {
+export interface ChapterTitleProps {
   /**
    * Specify text to be displayed when no chapter title is available.
    */

--- a/packages/vidstack/src/exports/components.ts
+++ b/packages/vidstack/src/exports/components.ts
@@ -65,7 +65,14 @@ export * from '../components/ui/time';
 export * from '../components/ui/thumbnails/thumbnail';
 export * from '../components/ui/thumbnails/thumbnail-loader';
 
+// Spinner
+export type { SpinnerProps } from '../elements/define/spinner-element';
+
+// Chapter Title
+export type { ChapterTitleProps } from '../elements/define/chapter-title-element';
+
 // Layouts
+export type { MediaLayoutProps } from '../elements/define/layouts/layout-element';
 export type { DefaultLayoutProps } from '../components/layouts/default/props';
 export type {
   DefaultLayoutWord,


### PR DESCRIPTION
## Summary

- Add missing `export` keyword to `ChapterTitleProps` in `src/elements/define/chapter-title-element.ts`
- Re-export `ChapterTitleProps`, `MediaLayoutProps`, and `SpinnerProps` from `src/exports/components.ts`

These three types are imported by the generated `vue.d.ts` from `'./index'`, but were never exported from the public barrel. This silently breaks the entire `declare module 'vue'` augmentation, causing all vidstack custom elements to be unrecognized in Vue templates.

Fixes #1759

## Test plan

- [ ] Create a Vue + TypeScript project with `skipLibCheck: false` and `strictTemplates: true`
- [ ] Import `vidstack/vue` types and use vidstack custom elements in a template
- [ ] Run `npx vue-tsc --noEmit` and confirm no missing export or TS2339 errors