### PR TITLE
Height fix

### DIFF
--- a/packages/vidstack/styles/player/base.css
+++ b/packages/vidstack/styles/player/base.css
@@ -101,7 +101,7 @@
 }
 
 iframe.vds-youtube[data-no-controls] {
-  height: 1000%;
+  height: 100%;
 }
 
 .vds-blocker {


### PR DESCRIPTION
Height was set to 1000% which would cause black screens for some users who would be using the vidstack player.
