### PR TITLE
fix(react): guard media store fallback ref

### DIFF
--- a/packages/react/src/hooks/use-media-state.ts
+++ b/packages/react/src/hooks/use-media-state.ts
@@ -54,5 +54,5 @@ export function useMediaStore(
     );
   }
 
-  return useSignalRecord(ref?.current ? ref.current.$state : $state || initialMediaStore);
+  return useSignalRecord(ref?.current?.$state || $state || initialMediaStore);
 }


### PR DESCRIPTION
## Summary

- Guard `useMediaStore(playerRef)` against a mounted player ref whose `$state` is temporarily nullish.
- Fall back to the media context state or initial media store, matching the defensive `useMediaState` behavior.

Fixes #1698.

## Validation

- `pnpm --filter @vidstack/react typecheck`

## Tests

- No focused hook test was added because `@vidstack/react` does not currently have a test script or existing React hook test pattern in this repo.
