### PR TITLE
fix(vidstack): allow casting dash sources

### DIFF
--- a/packages/vidstack/src/utils/mime.test.ts
+++ b/packages/vidstack/src/utils/mime.test.ts
@@ -1,0 +1,21 @@
+import { canGoogleCastSrc } from './mime';
+
+describe(canGoogleCastSrc.name, function () {
+  it('accepts DASH sources by type', function () {
+    expect(
+      canGoogleCastSrc({
+        src: 'https://example.com/manifest',
+        type: 'application/dash+xml',
+      }),
+    ).to.equal(true);
+  });
+
+  it('accepts DASH sources by extension', function () {
+    expect(
+      canGoogleCastSrc({
+        src: 'https://example.com/manifest.mpd',
+        type: '',
+      }),
+    ).to.equal(true);
+  });
+});

--- a/packages/vidstack/src/utils/mime.ts
+++ b/packages/vidstack/src/utils/mime.ts
@@ -81,7 +81,9 @@ export function isDASHSrc({ src, type }: Src): boolean {
 }
 
 export function canGoogleCastSrc(src: Src): boolean {
-  return isString(src.src) && (isAudioSrc(src) || isVideoSrc(src) || isHLSSrc(src));
+  return (
+    isString(src.src) && (isAudioSrc(src) || isVideoSrc(src) || isHLSSrc(src) || isDASHSrc(src))
+  );
 }
 
 export function isMediaStream(src: unknown): src is MediaStream {


### PR DESCRIPTION
## Summary

- Allow `canGoogleCastSrc` to accept DASH sources via the existing `isDASHSrc` utility.
- Add focused mime utility coverage for DASH MIME type and `.mpd` extension Cast eligibility.

## Research

Google Cast Web Receiver documentation lists MPEG-DASH as a supported adaptive streaming protocol when using the Web Receiver SDK. This change only updates Vidstack's sender-side Cast eligibility check so supported DASH sources can expose the Cast button; it does not change dash.js integration or broader DASH provider behavior.

Fixes #1631.

## Validation

- `pnpm --filter vidstack test -- src/utils/mime.test.ts`
- `pnpm --filter vidstack typecheck`