### PR TITLE
fix(vidstack): export missing public types

### DIFF
--- a/packages/vidstack/src/elements/define/chapter-title-element.ts
+++ b/packages/vidstack/src/elements/define/chapter-title-element.ts
@@ -4,7 +4,7 @@ import { Host } from 'maverick.js/element';
 import { useMediaContext, type MediaContext } from '../../core/api/media-context';
 import { watchCueTextChange } from '../../core/tracks/text/utils';
 
-interface ChapterTitleProps {
+export interface ChapterTitleProps {
   /**
    * Specify text to be displayed when no chapter title is available.
    */

--- a/packages/vidstack/src/exports/components.ts
+++ b/packages/vidstack/src/exports/components.ts
@@ -77,3 +77,8 @@ export type {
   PlyrLayoutTranslations,
 } from '../components/layouts/plyr/translations';
 export { usePlyrLayoutClasses } from '../components/layouts/plyr/plyr-layout';
+
+// Elements
+export type { ChapterTitleProps } from '../elements/define/chapter-title-element';
+export type { MediaLayoutProps } from '../elements/define/layouts/layout-element';
+export type { SpinnerProps } from '../elements/define/spinner-element';

--- a/packages/vidstack/src/exports/providers.ts
+++ b/packages/vidstack/src/exports/providers.ts
@@ -32,6 +32,7 @@ export type { DASHProvider } from '../providers/dash/provider';
 export type { GoogleCastLoader } from '../providers/google-cast/loader';
 export type { GoogleCastProvider } from '../providers/google-cast/provider';
 export type * from '../providers/google-cast/events';
+export type * from '../providers/google-cast/types';
 
 // Vimeo
 export { VimeoProviderLoader } from '../providers/vimeo/loader';


### PR DESCRIPTION
## Summary

- Export `GoogleCastOptions` from the public provider exports so `MediaPlayerProps` does not reference an unexported type.
- Export `ChapterTitleProps`, `MediaLayoutProps`, and `SpinnerProps` from the public `vidstack` surface used by generated framework typings.

Fixes #1757
Fixes #1759

## Validation

- `pnpm --filter vidstack typecheck`
- `pnpm --filter vidstack types`
- `pnpm --filter vidstack analyze`
- `git diff --check`
