### PR TITLE
fix(react): suppress Plyr layout hydration warning

### DIFF
--- a/packages/react/src/components/layouts/plyr/layout.tsx
+++ b/packages/react/src/components/layouts/plyr/layout.tsx
@@ -111,6 +111,7 @@ const PlyrLayout = React.forwardRef<HTMLElement, PlyrLayoutElementProps>(
           className={
             __SERVER__ ? `plyr plyr--full-ui plyr--${$viewType} ${className || ''}` : undefined
           }
+          suppressHydrationWarning
           ref={composeRefs(setEl, forwardRef) as any}
         >
           {$viewType === 'audio' ? (


### PR DESCRIPTION
## Summary

- suppress hydration checking on the React Plyr layout root
- preserve the existing server-only initial Plyr classes so the runtime classList controller can own client-side state classes

Fixes #1610.

## Validation

- `pnpm --filter @vidstack/react typecheck`

No focused SSR hydration test exists for the Plyr layout path.