### PR TITLE
fix(vidstack): preserve sub-second seek targets

### DIFF
--- a/packages/vidstack/src/core/api/player-state.test.ts
+++ b/packages/vidstack/src/core/api/player-state.test.ts
@@ -1,0 +1,45 @@
+import { boundTime } from './player-state';
+
+it('does not snap sub-second seek requests to the seekable start', () => {
+  expect(boundTime(0.8, createStore())).to.equal(0.8);
+});
+
+it('still allows seeking to the exact start', () => {
+  expect(boundTime(0, createStore())).to.equal(0);
+});
+
+it('does not snap clipped sub-second seek requests to the clip start', () => {
+  expect(
+    boundTime(0.8, createStore({ clipStartTime: 30, seekableStart: 30, seekableEnd: 40 })),
+  ).to.equal(30.8);
+});
+
+function createStore(overrides: Partial<StoreValues> = {}) {
+  const values = {
+    bufferedStart: 0,
+    clipStartTime: 0,
+    isLiveDVR: false,
+    liveDVRWindow: 0,
+    seekableEnd: 10,
+    seekableStart: 0,
+    ...overrides,
+  };
+
+  return {
+    bufferedStart: () => values.bufferedStart,
+    clipStartTime: () => values.clipStartTime,
+    isLiveDVR: () => values.isLiveDVR,
+    liveDVRWindow: () => values.liveDVRWindow,
+    seekableEnd: () => values.seekableEnd,
+    seekableStart: () => values.seekableStart,
+  } as any;
+}
+
+interface StoreValues {
+  bufferedStart: number;
+  clipStartTime: number;
+  isLiveDVR: boolean;
+  liveDVRWindow: number;
+  seekableEnd: number;
+  seekableStart: number;
+}

--- a/packages/vidstack/src/core/api/player-state.ts
+++ b/packages/vidstack/src/core/api/player-state.ts
@@ -917,8 +917,8 @@ export interface MediaPlayerQuery {
 
 export function boundTime(time: number, store: MediaStore) {
   const clippedTime = time + store.clipStartTime(),
-    isStart = Math.floor(time) === Math.floor(store.seekableStart()),
-    isEnd = Math.floor(clippedTime) === Math.floor(store.seekableEnd());
+    isStart = clippedTime <= store.seekableStart(),
+    isEnd = clippedTime >= store.seekableEnd();
 
   if (isStart) {
     return store.seekableStart();


### PR DESCRIPTION
## Summary

- stop treating every seek within the same floored second as the seekable boundary
- preserve sub-second seek targets near the start of short media
- add focused `boundTime` regression coverage for unclipped and clipped media

Fixes #1622.

## Validation

- `pnpm --filter vidstack exec vitest --run src/core/api/player-state.test.ts`
- `pnpm --filter vidstack typecheck`