### PR TITLE
fix(vidstack): preserve default layout classes in Svelte

### DIFF
--- a/packages/vidstack/src/elements/define/layouts/default/audio-layout-element.ts
+++ b/packages/vidstack/src/elements/define/layouts/default/audio-layout-element.ts
@@ -48,12 +48,13 @@ export class MediaAudioLayoutElement
 
     this.#media = useMediaContext();
 
-    this.classList.add('vds-audio-layout');
+    this.#addLayoutClass();
 
     this.#setupWatchScrubbing();
   }
 
   protected onConnect() {
+    this.#addLayoutClass();
     setLayoutName('audio', () => this.isMatch);
     this.#setupMenuContainer();
   }
@@ -64,6 +65,10 @@ export class MediaAudioLayoutElement
 
   #render() {
     return this.isMatch ? Layout() : null;
+  }
+
+  #addLayoutClass() {
+    this.classList.add('vds-audio-layout');
   }
 
   #setupMenuContainer() {

--- a/packages/vidstack/src/elements/define/layouts/default/video-layout-element.ts
+++ b/packages/vidstack/src/elements/define/layouts/default/video-layout-element.ts
@@ -50,16 +50,21 @@ export class MediaVideoLayoutElement
 
     this.#media = useMediaContext();
 
-    this.classList.add('vds-video-layout');
+    this.#addLayoutClass();
   }
 
   protected onConnect() {
+    this.#addLayoutClass();
     setLayoutName('video', () => this.isMatch);
     this.#setupMenuContainer();
   }
 
   render() {
     return $signal(this.#render.bind(this));
+  }
+
+  #addLayoutClass() {
+    this.classList.add('vds-video-layout');
   }
 
   #setupMenuContainer() {


### PR DESCRIPTION
## Summary

- reapply required default audio/video layout classes during connect
- prevent framework-generated class assignments, such as Svelte scoped styles, from permanently clobbering `vds-audio-layout` / `vds-video-layout`

Fixes #1568.

## Validation

- `pnpm --filter vidstack typecheck`

Manual SvelteKit runtime verification was not run in this pass.