### PR TITLE
Fix operator precedence bug dropping custom className on iframe embeds

### DIFF
--- a/packages/react/src/components/provider.tsx
+++ b/packages/react/src/components/provider.tsx
@@ -147,9 +147,8 @@ function MediaOutlet({ provider, mediaProps, iframeProps }: MediaOutletProps) {
         React.createElement('iframe', {
           ...iframeProps,
           className:
-            (iframeProps?.className ? `${iframeProps.className} ` : '') + isYouTubeEmbed
-              ? 'vds-youtube'
-              : 'vds-vimeo',
+            (iframeProps?.className ? `${iframeProps.className} ` : "") +
+            (isYouTubeEmbed ? "vds-youtube" : "vds-vimeo"),
           suppressHydrationWarning: true,
           tabIndex: !$nativeControls ? -1 : undefined,
           'aria-hidden': 'true',


### PR DESCRIPTION
### Problem

The className concatenation for the iframe embed had a missing set of parentheses, causing a subtle operator precedence bug:

```
(iframeProps?.className ? `${iframeProps.className} ` : '') + isYouTubeEmbed
  ? 'vds-youtube'
  : 'vds-vimeo',
```

Since + has higher precedence than the ternary ?:, this actually evaluates as:

```
((iframeProps?.className ? `${iframeProps.className} ` : '') + isYouTubeEmbed)
  ? 'vds-youtube'
  : 'vds-vimeo'

```

### Two consequences:

1. Any iframeProps.className passed in gets concatenated with the string-coerced isYouTubeEmbed value into a throwaway string, then discarded — the custom class never makes it onto the element.
2. That concatenated string is always non-empty, so it's always truthy — meaning the ternary always resolves to 'vds-youtube', regardless of the actual value of isYouTubeEmbed.