### PR TITLE
fix: TimeSlider.Value throws TypeError in Next.js production after client nav...

### DIFF
--- a/packages/vidstack/src/components/ui/sliders/slider-value.ts
+++ b/packages/vidstack/src/components/ui/sliders/slider-value.ts
@@ -47,6 +47,8 @@ export class SliderValue extends Component<SliderValueProps> {
    */
   @method
   getValueText() {
+    if (!this.scope || !this.#slider || !this.#format) return '';
+
     const {
         type,
         format: $format,


### PR DESCRIPTION
Fixes #1852

## Root cause

SliderValue.getValueText() runs on a destroyed component instance

## Changes

- Guard `SliderValue.getValueText()` against being called after the maverick instance has been destroyed (or before its slider state/format context is resolved) by returning an empty string, following the existing `if (!this.scope) return;` pattern used in slider-chapters.ts. Added a focused regression test.