### PR TITLE
fix(vidstack): guard localStorage access when unavailable

### DIFF
--- a/packages/react/src/components/layouts/default/ui/menus/items/menu-checkbox.tsx
+++ b/packages/react/src/components/layouts/default/ui/menus/items/menu-checkbox.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { isBoolean, isKeyboardClick } from 'maverick.js/std';
+import { LocalStorage } from 'vidstack';
 
 export interface DefaultMenuCheckboxProps {
   label: string;
@@ -21,7 +22,7 @@ function DefaultMenuCheckbox({
     [isActive, setIsActive] = React.useState(false);
 
   React.useEffect(() => {
-    const savedValue = storageKey ? localStorage.getItem(storageKey) : null,
+    const savedValue = storageKey ? LocalStorage.getItem(storageKey) : null,
       checked = !!(savedValue ?? defaultChecked);
     setIsChecked(checked);
     onChange?.(checked);
@@ -37,7 +38,7 @@ function DefaultMenuCheckbox({
     const toggledCheck = !isChecked;
 
     setIsChecked(toggledCheck);
-    if (storageKey) localStorage.setItem(storageKey, toggledCheck ? '1' : '');
+    if (storageKey) LocalStorage.setItem(storageKey, toggledCheck ? '1' : '');
 
     onChange?.(toggledCheck, event?.nativeEvent);
 

--- a/packages/vidstack/src/core/font/font-options.ts
+++ b/packages/vidstack/src/core/font/font-options.ts
@@ -2,6 +2,7 @@ import { signal, type WriteSignal } from 'maverick.js';
 import { camelToKebabCase, isString } from 'maverick.js/std';
 
 import type { DefaultLayoutTranslations } from '../../components/layouts/default/translations';
+import { LocalStorage } from '../../utils/storage';
 
 export const FONT_COLOR_OPTION: FontOption = {
   type: 'color',
@@ -67,7 +68,7 @@ export type FontSignal = keyof typeof FONT_DEFAULTS;
 
 if (!__SERVER__) {
   for (const type of Object.keys(FONT_SIGNALS)) {
-    const value = localStorage.getItem(`vds-player:${camelToKebabCase(type)}`);
+    const value = LocalStorage.getItem(`vds-player:${camelToKebabCase(type)}`);
     if (isString(value)) FONT_SIGNALS[type].set(value);
   }
 }

--- a/packages/vidstack/src/core/font/font-vars.ts
+++ b/packages/vidstack/src/core/font/font-vars.ts
@@ -3,6 +3,7 @@ import { camelToKebabCase, keysOf } from 'maverick.js/std';
 
 import type { MediaPlayer } from '../../components/player';
 import { hexToRgb } from '../../utils/color';
+import { LocalStorage } from '../../utils/storage';
 import { useMediaContext } from '../api/media-context';
 import { FONT_DEFAULTS, FONT_SIGNALS, type FontSignal } from './font-options';
 
@@ -33,9 +34,9 @@ export function updateFontCssVars() {
           }
 
           if (isDefaultVarValue) {
-            localStorage.removeItem(storageKey);
+            LocalStorage.removeItem(storageKey);
           } else {
-            localStorage.setItem(storageKey, value);
+            LocalStorage.setItem(storageKey, value);
           }
         });
       }

--- a/packages/vidstack/src/core/state/media-storage.test.ts
+++ b/packages/vidstack/src/core/state/media-storage.test.ts
@@ -1,0 +1,22 @@
+import { vi } from 'vitest';
+
+import type { Src } from '../api/src-types';
+import { LocalMediaStorage } from './media-storage';
+
+describe('LocalMediaStorage', function () {
+  afterEach(function () {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not throw when `localStorage` is unavailable', async function () {
+    // Some mobile WebViews expose `localStorage` as `null` (see issue #1444).
+    vi.stubGlobal('localStorage', null);
+
+    const storage = new LocalMediaStorage(),
+      src: Src = { src: 'https://example.com/video.mp4', type: 'video/mp4' };
+
+    expect(() => storage.onChange(src, 'media-id', 'player-id')).not.toThrow();
+    await expect(storage.setVolume(0.5)).resolves.toBeUndefined();
+    await expect(storage.setTime(10, true)).resolves.toBeUndefined();
+  });
+});

--- a/packages/vidstack/src/core/state/media-storage.ts
+++ b/packages/vidstack/src/core/state/media-storage.ts
@@ -1,6 +1,7 @@
 import throttle from 'just-throttle';
 import type { MaybeStopEffect } from 'maverick.js';
 
+import { LocalStorage } from '../../utils/storage';
 import type { Src } from '../api/src-types';
 
 export interface MediaStorage {
@@ -151,8 +152,8 @@ export class LocalMediaStorage implements MediaStorage {
   }
 
   onChange(src: Src, mediaId: string | null, playerId = 'vds-player') {
-    const savedData = playerId ? localStorage.getItem(playerId) : null,
-      savedTime = mediaId ? localStorage.getItem(mediaId) : null;
+    const savedData = playerId ? LocalStorage.getItem(playerId) : null,
+      savedTime = mediaId ? LocalStorage.getItem(mediaId) : null;
 
     this.playerId = playerId;
     this.mediaId = mediaId;
@@ -173,14 +174,14 @@ export class LocalMediaStorage implements MediaStorage {
   protected save() {
     if (__SERVER__ || !this.playerId) return;
     const data = JSON.stringify({ ...this.#data, time: undefined });
-    localStorage.setItem(this.playerId, data);
+    LocalStorage.setItem(this.playerId, data);
   }
 
   protected saveTimeThrottled = throttle(this.saveTime.bind(this), 1000);
   private saveTime() {
     if (__SERVER__ || !this.mediaId) return;
     const data = (this.#data.time ?? 0).toString();
-    localStorage.setItem(this.mediaId, data);
+    LocalStorage.setItem(this.mediaId, data);
   }
 }
 

--- a/packages/vidstack/src/elements/define/layouts/default/ui/menu/items/menu-checkbox.ts
+++ b/packages/vidstack/src/elements/define/layouts/default/ui/menu/items/menu-checkbox.ts
@@ -5,6 +5,7 @@ import { isKeyboardClick } from 'maverick.js/std';
 import { useDefaultLayoutContext } from '../../../../../../../components/layouts/default/context';
 import type { DefaultLayoutWord } from '../../../../../../../components/layouts/default/translations';
 import { $ariaBool } from '../../../../../../../utils/aria';
+import { LocalStorage } from '../../../../../../../utils/storage';
 import { $signal } from '../../../../../../lit/directives/signal';
 import { $i18n } from '../../utils';
 
@@ -22,7 +23,7 @@ export function DefaultMenuCheckbox({
   onChange(checked: boolean, trigger?: Event): void;
 }) {
   const { translations } = useDefaultLayoutContext(),
-    savedValue = storageKey ? localStorage.getItem(storageKey) : null,
+    savedValue = storageKey ? LocalStorage.getItem(storageKey) : null,
     $checked = signal(!!(savedValue ?? defaultChecked)),
     $active = signal(false),
     $ariaChecked = $signal($ariaBool($checked)),
@@ -37,7 +38,7 @@ export function DefaultMenuCheckbox({
   function onPress(event?: PointerEvent) {
     if (event?.button === 1) return;
     $checked.set((checked) => !checked);
-    if (storageKey) localStorage.setItem(storageKey, $checked() ? '1' : '');
+    if (storageKey) LocalStorage.setItem(storageKey, $checked() ? '1' : '');
     onChange($checked(), event);
     $active.set(false);
   }

--- a/packages/vidstack/src/exports/utils.ts
+++ b/packages/vidstack/src/exports/utils.ts
@@ -1,6 +1,9 @@
 // Network
 export { getDownloadFile, type FileDownloadInfo } from '../utils/network';
 
+// Storage
+export { LocalStorage } from '../utils/storage';
+
 // Time
 export { formatTime, formatSpokenTime } from '../utils/time';
 

--- a/packages/vidstack/src/utils/storage.ts
+++ b/packages/vidstack/src/utils/storage.ts
@@ -1,0 +1,30 @@
+/**
+ * A safe wrapper around `localStorage` for environments where it's not available. In some
+ * mobile WebViews (or when the user has disabled storage) `localStorage` can be `null` or throw
+ * on access, which would otherwise crash the player.
+ *
+ * @see {@link https://github.com/vidstack/player/issues/1444}
+ */
+export const LocalStorage = {
+  getItem(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // no-op
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // no-op
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add a `LocalStorage` wrapper in `utils/storage.ts` that guards `getItem`/`setItem`/`removeItem` in a try/catch
- route the player's storage reads/writes (media storage, font vars/options, default-layout menu checkbox) through it

## Why

Some mobile WebViews expose `localStorage` as `null` (or throw on access when storage is disabled), so the direct `localStorage.getItem(...)` calls throw a `TypeError` and crash the player on init. The wrapper returns `null` / no-ops in that case instead of throwing.

`pnpm --filter vidstack test` passes (64 tests), including a new `media-storage.test.ts` that stubs `localStorage` as `null` and asserts `LocalMediaStorage` doesn't throw. typecheck/oxfmt not run in this pass.

Fixes #1444.