### PR TITLE
fix: guard HLS load target and PiP null video

### DIFF
--- a/packages/vidstack/src/providers/hls/loader.test.ts
+++ b/packages/vidstack/src/providers/hls/loader.test.ts
@@ -1,0 +1,28 @@
+import { HLSProviderLoader } from './loader';
+
+describe('HLSProviderLoader.load', function () {
+  afterEach(function () {
+    Reflect.deleteProperty(document, 'pictureInPictureEnabled');
+  });
+
+  it('does not construct the provider with a null target if unmounted during import', async function () {
+    Object.defineProperty(document, 'pictureInPictureEnabled', {
+      configurable: true,
+      value: true,
+    });
+
+    const loader = new HLSProviderLoader(),
+      video = document.createElement('video'),
+      ctx = { notify() {} } as any;
+
+    loader.target = video;
+
+    const load = loader.load(ctx);
+    loader.target = null as any;
+
+    const provider = await load;
+
+    expect(provider).to.have.property('type', 'hls');
+    expect(provider.video).to.equal(video);
+  });
+});

--- a/packages/vidstack/src/providers/hls/loader.ts
+++ b/packages/vidstack/src/providers/hls/loader.ts
@@ -22,12 +22,22 @@ export class HLSProviderLoader
       throw Error('[vidstack] can not load hls provider server-side');
     }
 
-    if (__DEV__ && !this.target) {
+    const target = this.target;
+
+    if (__DEV__ && !target) {
       throw Error(
         '[vidstack] `<video>` element was not found - did you forget to include `<media-provider>`?',
       );
     }
 
-    return new (await import('./provider')).HLSProvider(this.target, context);
+    const { HLSProvider } = await import('./provider');
+
+    if (!target) {
+      throw Error(
+        '[vidstack] `<video>` element was not found - did you forget to include `<media-provider>`?',
+      );
+    }
+
+    return new HLSProvider(target, context);
   }
 }

--- a/packages/vidstack/src/utils/support.test.ts
+++ b/packages/vidstack/src/utils/support.test.ts
@@ -1,0 +1,37 @@
+import { canUsePictureInPicture } from './support';
+
+describe(canUsePictureInPicture.name, function () {
+  afterEach(function () {
+    Reflect.deleteProperty(document, 'pictureInPictureEnabled');
+  });
+
+  it('returns false when video is null even if picture-in-picture is enabled', function () {
+    Object.defineProperty(document, 'pictureInPictureEnabled', {
+      configurable: true,
+      value: true,
+    });
+
+    expect(canUsePictureInPicture(null)).to.equal(false);
+  });
+
+  it('returns true for a video element when picture-in-picture is enabled', function () {
+    Object.defineProperty(document, 'pictureInPictureEnabled', {
+      configurable: true,
+      value: true,
+    });
+
+    expect(canUsePictureInPicture(document.createElement('video'))).to.equal(true);
+  });
+
+  it('returns false when the video has picture-in-picture disabled', function () {
+    Object.defineProperty(document, 'pictureInPictureEnabled', {
+      configurable: true,
+      value: true,
+    });
+
+    const video = document.createElement('video');
+    video.disablePictureInPicture = true;
+
+    expect(canUsePictureInPicture(video)).to.equal(false);
+  });
+});

--- a/packages/vidstack/src/utils/support.ts
+++ b/packages/vidstack/src/utils/support.ts
@@ -83,8 +83,8 @@ export function canPlayHLSNatively(video?: HTMLVideoElement | null): boolean {
  * @see {@link https://developers.google.com/web/updates/2018/10/watch-video-using-picture-in-picture}
  */
 export function canUsePictureInPicture(video: HTMLVideoElement | null): boolean {
-  if (__SERVER__) return false;
-  return !!document.pictureInPictureEnabled && !video?.disablePictureInPicture;
+  if (__SERVER__ || !video) return false;
+  return !!document.pictureInPictureEnabled && !video.disablePictureInPicture;
 }
 
 /**


### PR DESCRIPTION
### Related:

Fixes #1771. Thanks @rbao for the report and for identifying both sites.

### Description:

Unmounting `<MediaPlayer>` while the HLS provider chunk is still dynamically importing can construct `HLSProvider` with a nulled `loader.target`. `canUsePictureInPicture(null)` then returns `true` because `!video?.disablePictureInPicture` is true when `video` is null, so `VideoPictureInPicture` is created on null and `EventsController.add` throws `TypeError: Cannot read properties of null (reading 'addEventListener')`.

This is the same predicate class as #989 (`canUseVideoPresentation`); that fix did not cover picture-in-picture.

- `HLSProviderLoader.load` now snapshots `const target = this.target` before `await import('./provider')` and constructs with that element, or bails if it is null.
- `canUsePictureInPicture` requires a real video element.

### Ready?

Yes.

### Anything Else?

Unit tests in jsdom cover both sites (preferred over Slow 4G E2E). Scope is #1771 only.

### Review Process:

- [ ] `pnpm -F vidstack exec vitest --run src/utils/support.test.ts src/providers/hls/loader.test.ts`
- [ ] `canUsePictureInPicture(null)` is false when `document.pictureInPictureEnabled` is true
- [ ] Clearing `loader.target` during the HLS provider import no longer throws
